### PR TITLE
Quick hygiene: Field validation and API docstrings

### DIFF
--- a/src/minimal_agora/loop.py
+++ b/src/minimal_agora/loop.py
@@ -100,6 +100,7 @@ async def run_trajectory(
     trajectory_id: int = 0,
     agent_timeout: int = 300,
 ) -> Trajectory:
+    """Run a single simulation trajectory, returning the completed Trajectory with outcome."""
     board = Board(workspace)
     agent_semaphore = asyncio.Semaphore(scenario.max_concurrent_agents)
 

--- a/src/minimal_agora/models.py
+++ b/src/minimal_agora/models.py
@@ -19,6 +19,8 @@ class AgentRole(str, Enum):
 
 
 class AgentConfig(BaseModel):
+    """Configuration for a single LLM agent within a simulation."""
+
     model_config = ConfigDict(extra="forbid")
 
     role: AgentRole
@@ -74,6 +76,8 @@ class InteractionConfig(BaseModel):
 
 
 class EntityConfig(BaseModel):
+    """Configuration for an entity (population, force, critic, or evaluator) in population mode."""
+
     model_config = ConfigDict(extra="forbid")
 
     name: str
@@ -110,6 +114,8 @@ class FitnessConfig(BaseModel):
 
 
 class Scenario(BaseModel):
+    """Top-level simulation scenario defining agents, rules, and termination conditions."""
+
     model_config = ConfigDict(extra="forbid")
 
     name: str
@@ -126,7 +132,7 @@ class Scenario(BaseModel):
     wildcards: list[WildcardEvent] = Field(default_factory=list)
     wildcards_enabled: bool = False
     description: str = ""
-    max_concurrent_agents: int = 8
+    max_concurrent_agents: int = Field(default=8, ge=1)
 
 
 class Proposal(BaseModel):
@@ -186,6 +192,8 @@ class TrajectoryOutcome(BaseModel):
 
 
 class Trajectory(BaseModel):
+    """Record of a single simulation run including steps and final outcome."""
+
     model_config = ConfigDict(extra="forbid")
 
     scenario_name: str

--- a/src/minimal_agora/runner.py
+++ b/src/minimal_agora/runner.py
@@ -14,6 +14,7 @@ async def run_batch(
     concurrency: int = 4,
     agent_timeout: int = 300,
 ) -> list[Trajectory]:
+    """Run multiple trajectories in parallel with bounded concurrency."""
     output_dir.mkdir(parents=True, exist_ok=True)
     n = scenario.n_trajectories
 

--- a/src/minimal_agora/scenario.py
+++ b/src/minimal_agora/scenario.py
@@ -14,6 +14,7 @@ logger = structlog.stdlib.get_logger(__name__)
 
 
 def load_scenario(path: str | Path) -> Scenario:
+    """Load and validate a scenario from a YAML or JSON file."""
     path = Path(path)
     logger.info("scenario.load", path=str(path), format=path.suffix)
     with open(path) as f:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,8 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from minimal_agora.analysis import aggregate_outcomes, format_report
 from minimal_agora.board import Board, _deep_merge
 from minimal_agora.models import (
@@ -569,6 +571,17 @@ def test_max_concurrent_agents_configurable():
         max_concurrent_agents=4,
     )
     assert scenario.max_concurrent_agents == 4
+
+
+def test_max_concurrent_agents_rejects_zero():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Scenario(
+            name="test", mode=SimMode.COUNTERFACTUAL,
+            initial_state={"x": 0}, step_budget=5,
+            max_concurrent_agents=0,
+        )
 
 
 def test_convergence_detection():


### PR DESCRIPTION
Closes #6

## Changes

- **Field validation**: Changed `max_concurrent_agents: int = 8` to `Field(default=8, ge=1)` in `models.py` to prevent `asyncio.Semaphore(0)` deadlock (code review finding from PR #4)
- **API docstrings**: Added concise one-line docstrings to all 7 public API exports at their definition sites: `Scenario`, `Trajectory`, `AgentConfig`, `EntityConfig` (models.py), `run_trajectory` (loop.py), `run_batch` (runner.py), `load_scenario` (scenario.py)
- **Validation test**: Added `test_max_concurrent_agents_rejects_zero` confirming `Scenario(max_concurrent_agents=0)` raises `ValidationError`
- All 65 tests pass, ruff clean, mypy clean