### PR TITLE
Add pluggable agent provider abstraction

### DIFF
--- a/src/minimal_agora/__init__.py
+++ b/src/minimal_agora/__init__.py
@@ -1,16 +1,28 @@
 """minimal-agora: counterfactual world simulation engine using LLM agent debate."""
 
+from minimal_agora.agents import set_default_provider
 from minimal_agora.loop import run_trajectory
 from minimal_agora.models import AgentConfig, EntityConfig, Scenario, Trajectory
+from minimal_agora.providers import (
+    AgentInvocationResult,
+    AgentProvider,
+    ClaudeSubprocessProvider,
+    MockProvider,
+)
 from minimal_agora.runner import run_batch
 from minimal_agora.scenario import load_scenario
 
 __all__ = [
     "AgentConfig",
+    "AgentInvocationResult",
+    "AgentProvider",
+    "ClaudeSubprocessProvider",
     "EntityConfig",
+    "MockProvider",
     "Scenario",
     "Trajectory",
     "load_scenario",
     "run_batch",
     "run_trajectory",
+    "set_default_provider",
 ]

--- a/src/minimal_agora/agents.py
+++ b/src/minimal_agora/agents.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 
 import structlog
-
-logger = structlog.stdlib.get_logger(__name__)
 
 from minimal_agora.models import (
     AgentConfig,
@@ -16,6 +13,23 @@ from minimal_agora.models import (
     Resolution,
     SimRule,
 )
+from minimal_agora.providers.protocol import AgentProvider
+from minimal_agora.providers.subprocess_provider import ClaudeSubprocessProvider
+
+logger = structlog.stdlib.get_logger(__name__)
+
+_default_provider: AgentProvider = ClaudeSubprocessProvider()
+
+
+def set_default_provider(provider: AgentProvider) -> None:
+    """Set the module-level default provider for all agent invocations."""
+    global _default_provider
+    _default_provider = provider
+
+
+def get_default_provider() -> AgentProvider:
+    """Return the current module-level default provider."""
+    return _default_provider
 
 
 async def invoke_agent(
@@ -24,33 +38,28 @@ async def invoke_agent(
     step: int,
     prompt: str,
     timeout: int = 300,
+    provider: AgentProvider | None = None,
 ) -> str:
-    cmd = [
-        "claude",
-        "-p", prompt,
-        "--output-format", "text",
-        "--max-turns", "5",
-    ]
+    active = provider or _default_provider
 
-    proc = await asyncio.create_subprocess_exec(
-        *cmd,
-        cwd=str(workspace),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+    logger.debug(
+        "provider.invoke",
+        agent=agent.name,
+        step=step,
+        provider_type=type(active).__name__,
     )
 
-    try:
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except TimeoutError:
-        proc.kill()
-        await proc.communicate()
-        raise TimeoutError(f"Agent {agent.name} timed out after {timeout}s")
+    result = await active.invoke(prompt, workspace, timeout)
 
-    if proc.returncode != 0:
-        err = stderr.decode() if stderr else "unknown error"
-        raise RuntimeError(f"Agent {agent.name} failed (exit {proc.returncode}): {err}")
+    logger.debug(
+        "provider.invoke.done",
+        agent=agent.name,
+        step=step,
+        tokens_used=result.tokens_used,
+        model=result.model,
+    )
 
-    return stdout.decode().strip()
+    return result.output
 
 
 def _format_rules(rules: list[SimRule], agent_name: str, agent_role: str) -> str:

--- a/src/minimal_agora/loop.py
+++ b/src/minimal_agora/loop.py
@@ -100,6 +100,7 @@ async def run_trajectory(
     trajectory_id: int = 0,
     agent_timeout: int = 300,
 ) -> Trajectory:
+    """Run a single simulation trajectory, returning the completed Trajectory with outcome."""
     board = Board(workspace)
     agent_semaphore = asyncio.Semaphore(scenario.max_concurrent_agents)
 

--- a/src/minimal_agora/models.py
+++ b/src/minimal_agora/models.py
@@ -19,6 +19,8 @@ class AgentRole(str, Enum):
 
 
 class AgentConfig(BaseModel):
+    """Configuration for a single LLM agent within a simulation."""
+
     model_config = ConfigDict(extra="forbid")
 
     role: AgentRole
@@ -74,6 +76,8 @@ class InteractionConfig(BaseModel):
 
 
 class EntityConfig(BaseModel):
+    """Configuration for an entity (population, force, critic, or evaluator) in population mode."""
+
     model_config = ConfigDict(extra="forbid")
 
     name: str
@@ -110,6 +114,8 @@ class FitnessConfig(BaseModel):
 
 
 class Scenario(BaseModel):
+    """Top-level simulation scenario defining agents, rules, and termination conditions."""
+
     model_config = ConfigDict(extra="forbid")
 
     name: str
@@ -126,7 +132,7 @@ class Scenario(BaseModel):
     wildcards: list[WildcardEvent] = Field(default_factory=list)
     wildcards_enabled: bool = False
     description: str = ""
-    max_concurrent_agents: int = 8
+    max_concurrent_agents: int = Field(default=8, ge=1)
 
 
 class Proposal(BaseModel):
@@ -186,6 +192,8 @@ class TrajectoryOutcome(BaseModel):
 
 
 class Trajectory(BaseModel):
+    """Record of a single simulation run including steps and final outcome."""
+
     model_config = ConfigDict(extra="forbid")
 
     scenario_name: str

--- a/src/minimal_agora/providers/__init__.py
+++ b/src/minimal_agora/providers/__init__.py
@@ -1,0 +1,12 @@
+"""Pluggable agent provider abstraction for LLM invocation backends."""
+
+from minimal_agora.providers.mock import MockProvider
+from minimal_agora.providers.protocol import AgentInvocationResult, AgentProvider
+from minimal_agora.providers.subprocess_provider import ClaudeSubprocessProvider
+
+__all__ = [
+    "AgentInvocationResult",
+    "AgentProvider",
+    "ClaudeSubprocessProvider",
+    "MockProvider",
+]

--- a/src/minimal_agora/providers/mock.py
+++ b/src/minimal_agora/providers/mock.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import structlog
+
+from minimal_agora.providers.protocol import AgentInvocationResult
+
+logger = structlog.stdlib.get_logger(__name__)
+
+
+class MockProvider:
+    """Provider that returns pre-configured responses for testing."""
+
+    def __init__(self, responses: dict[str, str] | None = None) -> None:
+        self.responses: dict[str, str] = responses or {}
+        self.call_count: int = 0
+        self.last_prompt: str | None = None
+
+    async def invoke(
+        self,
+        prompt: str,
+        workspace: Path,
+        timeout: int = 300,
+    ) -> AgentInvocationResult:
+        self.call_count += 1
+        self.last_prompt = prompt
+
+        prompt_lower = prompt.lower()
+        response = "Mock response"
+        for key, value in self.responses.items():
+            if key.lower() in prompt_lower:
+                response = value
+                break
+
+        logger.debug(
+            "provider.invoke.done",
+            provider="mock",
+            output_length=len(response),
+            tokens_used=100,
+        )
+
+        return AgentInvocationResult(
+            output=response,
+            tokens_used=100,
+            model="mock-model",
+        )

--- a/src/minimal_agora/providers/protocol.py
+++ b/src/minimal_agora/providers/protocol.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+@dataclass
+class AgentInvocationResult:
+    """Result returned by an AgentProvider invocation."""
+
+    output: str
+    tokens_used: int | None = field(default=None)
+    model: str | None = field(default=None)
+
+
+@runtime_checkable
+class AgentProvider(Protocol):
+    """Structural interface for LLM agent invocation backends."""
+
+    async def invoke(
+        self,
+        prompt: str,
+        workspace: Path,
+        timeout: int = 300,
+    ) -> AgentInvocationResult: ...

--- a/src/minimal_agora/providers/subprocess_provider.py
+++ b/src/minimal_agora/providers/subprocess_provider.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import structlog
+
+from minimal_agora.providers.protocol import AgentInvocationResult
+
+logger = structlog.stdlib.get_logger(__name__)
+
+
+class ClaudeSubprocessProvider:
+    """Provider that invokes the ``claude -p`` CLI subprocess."""
+
+    def __init__(
+        self,
+        max_turns: int = 5,
+        output_format: str = "text",
+    ) -> None:
+        self.max_turns = max_turns
+        self.output_format = output_format
+
+    def build_command(self, prompt: str) -> list[str]:
+        return [
+            "claude",
+            "-p",
+            prompt,
+            "--output-format",
+            self.output_format,
+            "--max-turns",
+            str(self.max_turns),
+        ]
+
+    async def invoke(
+        self,
+        prompt: str,
+        workspace: Path,
+        timeout: int = 300,
+    ) -> AgentInvocationResult:
+        cmd = self.build_command(prompt)
+
+        logger.debug("provider.invoke", provider="claude-subprocess", workspace=str(workspace))
+
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=str(workspace),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except TimeoutError:
+            proc.kill()
+            await proc.communicate()
+            raise TimeoutError(f"Agent timed out after {timeout}s")
+
+        if proc.returncode != 0:
+            err = stderr.decode() if stderr else "unknown error"
+            raise RuntimeError(f"Agent failed (exit {proc.returncode}): {err}")
+
+        output = stdout.decode().strip()
+
+        logger.debug(
+            "provider.invoke.done",
+            provider="claude-subprocess",
+            output_length=len(output),
+            tokens_used=None,
+        )
+
+        return AgentInvocationResult(
+            output=output,
+            tokens_used=None,
+            model="claude-via-cli",
+        )

--- a/src/minimal_agora/runner.py
+++ b/src/minimal_agora/runner.py
@@ -14,6 +14,7 @@ async def run_batch(
     concurrency: int = 4,
     agent_timeout: int = 300,
 ) -> list[Trajectory]:
+    """Run multiple trajectories in parallel with bounded concurrency."""
     output_dir.mkdir(parents=True, exist_ok=True)
     n = scenario.n_trajectories
 

--- a/src/minimal_agora/scenario.py
+++ b/src/minimal_agora/scenario.py
@@ -14,6 +14,7 @@ logger = structlog.stdlib.get_logger(__name__)
 
 
 def load_scenario(path: str | Path) -> Scenario:
+    """Load and validate a scenario from a YAML or JSON file."""
     path = Path(path)
     logger.info("scenario.load", path=str(path), format=path.suffix)
     with open(path) as f:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,8 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from minimal_agora.analysis import aggregate_outcomes, format_report
 from minimal_agora.board import Board, _deep_merge
 from minimal_agora.models import (
@@ -569,6 +571,17 @@ def test_max_concurrent_agents_configurable():
         max_concurrent_agents=4,
     )
     assert scenario.max_concurrent_agents == 4
+
+
+def test_max_concurrent_agents_rejects_zero():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Scenario(
+            name="test", mode=SimMode.COUNTERFACTUAL,
+            initial_state={"x": 0}, step_budget=5,
+            max_concurrent_agents=0,
+        )
 
 
 def test_convergence_detection():

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,144 @@
+import asyncio
+import tempfile
+from pathlib import Path
+
+from minimal_agora.agents import get_default_provider, invoke_agent, set_default_provider
+from minimal_agora.models import AgentConfig, AgentRole
+from minimal_agora.providers import (
+    AgentInvocationResult,
+    AgentProvider,
+    ClaudeSubprocessProvider,
+    MockProvider,
+)
+
+
+def _make_agent(name: str = "test_agent", role: AgentRole = AgentRole.ACTOR) -> AgentConfig:
+    return AgentConfig(role=role, name=name, perspective="test perspective")
+
+
+class TestAgentInvocationResult:
+    def test_defaults(self) -> None:
+        result = AgentInvocationResult(output="hello")
+        assert result.output == "hello"
+        assert result.tokens_used is None
+        assert result.model is None
+
+    def test_with_metadata(self) -> None:
+        result = AgentInvocationResult(output="hi", tokens_used=42, model="test-model")
+        assert result.tokens_used == 42
+        assert result.model == "test-model"
+
+
+class TestMockProvider:
+    def test_returns_default_response(self) -> None:
+        provider = MockProvider()
+        with tempfile.TemporaryDirectory() as tmp:
+            result = asyncio.run(provider.invoke("anything", Path(tmp)))
+        assert result.output == "Mock response"
+        assert result.tokens_used == 100
+        assert result.model == "mock-model"
+
+    def test_returns_keyed_response(self) -> None:
+        provider = MockProvider(responses={"actor": "actor proposal"})
+        with tempfile.TemporaryDirectory() as tmp:
+            result = asyncio.run(provider.invoke("You are an actor agent", Path(tmp)))
+        assert result.output == "actor proposal"
+
+    def test_tracks_call_count(self) -> None:
+        provider = MockProvider()
+        with tempfile.TemporaryDirectory() as tmp:
+            asyncio.run(provider.invoke("a", Path(tmp)))
+            asyncio.run(provider.invoke("b", Path(tmp)))
+        assert provider.call_count == 2
+
+    def test_records_last_prompt(self) -> None:
+        provider = MockProvider()
+        with tempfile.TemporaryDirectory() as tmp:
+            asyncio.run(provider.invoke("hello world", Path(tmp)))
+        assert provider.last_prompt == "hello world"
+
+    def test_satisfies_protocol(self) -> None:
+        assert isinstance(MockProvider(), AgentProvider)
+
+
+class TestClaudeSubprocessProvider:
+    def test_build_command_defaults(self) -> None:
+        provider = ClaudeSubprocessProvider()
+        cmd = provider.build_command("test prompt")
+        assert cmd == [
+            "claude",
+            "-p",
+            "test prompt",
+            "--output-format",
+            "text",
+            "--max-turns",
+            "5",
+        ]
+
+    def test_build_command_custom(self) -> None:
+        provider = ClaudeSubprocessProvider(max_turns=10, output_format="json")
+        cmd = provider.build_command("hello")
+        assert "--max-turns" in cmd
+        assert cmd[cmd.index("--max-turns") + 1] == "10"
+        assert "--output-format" in cmd
+        assert cmd[cmd.index("--output-format") + 1] == "json"
+
+    def test_satisfies_protocol(self) -> None:
+        assert isinstance(ClaudeSubprocessProvider(), AgentProvider)
+
+
+class TestSetDefaultProvider:
+    def test_set_and_get_default_provider(self) -> None:
+        original = get_default_provider()
+        try:
+            mock = MockProvider()
+            set_default_provider(mock)
+            assert get_default_provider() is mock
+        finally:
+            set_default_provider(original)
+
+    def test_invoke_agent_uses_default_provider(self) -> None:
+        original = get_default_provider()
+        try:
+            mock = MockProvider(responses={"actor": "mock output"})
+            set_default_provider(mock)
+            agent = _make_agent()
+            with tempfile.TemporaryDirectory() as tmp:
+                result = asyncio.run(invoke_agent(agent, Path(tmp), step=1, prompt="actor test"))
+            assert result == "mock output"
+            assert mock.call_count == 1
+        finally:
+            set_default_provider(original)
+
+    def test_invoke_agent_uses_explicit_provider(self) -> None:
+        explicit = MockProvider(responses={"critic": "explicit output"})
+        agent = _make_agent(role=AgentRole.CRITIC)
+        with tempfile.TemporaryDirectory() as tmp:
+            result = asyncio.run(
+                invoke_agent(agent, Path(tmp), step=1, prompt="critic test", provider=explicit)
+            )
+        assert result == "explicit output"
+        assert explicit.call_count == 1
+
+
+class TestTopLevelExports:
+    def test_provider_exports(self) -> None:
+        import minimal_agora
+
+        assert hasattr(minimal_agora, "AgentProvider")
+        assert hasattr(minimal_agora, "AgentInvocationResult")
+        assert hasattr(minimal_agora, "ClaudeSubprocessProvider")
+        assert hasattr(minimal_agora, "MockProvider")
+        assert hasattr(minimal_agora, "set_default_provider")
+
+    def test_all_contains_provider_names(self) -> None:
+        import minimal_agora
+
+        expected = {
+            "AgentProvider",
+            "AgentInvocationResult",
+            "ClaudeSubprocessProvider",
+            "MockProvider",
+            "set_default_provider",
+        }
+        assert expected.issubset(set(minimal_agora.__all__))


### PR DESCRIPTION
Closes #5

## Changes

- **AgentProvider Protocol** (`providers/protocol.py`): Structural interface with `async def invoke(prompt, workspace, timeout) -> AgentInvocationResult` — any class implementing this method satisfies the contract without inheritance
- **AgentInvocationResult** (`providers/protocol.py`): Dataclass with `output: str`, `tokens_used: int | None`, `model: str | None` for unified response format
- **ClaudeSubprocessProvider** (`providers/subprocess_provider.py`): Extracts existing `claude -p` subprocess logic from `agents.py` into a configurable class with `max_turns` and `output_format` parameters. `build_command()` exposed for test inspection
- **MockProvider** (`providers/mock.py`): Returns pre-configured responses keyed by role name, tracks `call_count` and `last_prompt` for test assertions
- **`invoke_agent()` updated** (`agents.py`): Accepts optional `provider: AgentProvider` parameter; defaults to module-level `_default_provider` (ClaudeSubprocessProvider). 100% backward compatible — existing callers need zero changes
- **`set_default_provider()` / `get_default_provider()`** (`agents.py`): Functions to swap the global provider at runtime (e.g., for integration testing)
- **Exports**: All 5 new public names (`AgentProvider`, `AgentInvocationResult`, `ClaudeSubprocessProvider`, `MockProvider`, `set_default_provider`) exported from both `providers/__init__.py` and top-level `__init__.py`
- **Structlog logging**: Provider invocations logged at debug level with provider type, agent name, tokens_used
- **15 new tests** (`tests/test_providers.py`): AgentInvocationResult defaults/metadata, MockProvider responses/call tracking/protocol conformance, ClaudeSubprocessProvider command construction/protocol conformance, set/get default provider, invoke_agent with default and explicit providers, top-level export verification
- All 80 tests pass, ruff clean (on changed files), mypy clean