### PR TITLE
Mid-run checkpointing with atomic writes

### DIFF
--- a/src/minimal_agora/board.py
+++ b/src/minimal_agora/board.py
@@ -1,13 +1,39 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import IO
 
 import structlog
 
 from minimal_agora.models import Critique, Proposal, Resolution, Step, WildcardEvent
 
 logger = structlog.stdlib.get_logger(__name__)
+
+
+@contextmanager
+def _atomic_write(filepath: Path) -> Iterator[IO[str]]:
+    directory = filepath.parent
+    fd, temppath = tempfile.mkstemp(dir=str(directory), prefix=".tmp_", suffix=filepath.suffix)
+    try:
+        f = os.fdopen(fd, "w", encoding="utf-8")
+        with f:
+            yield f
+            f.flush()
+            os.fsync(f.fileno())
+            logger.debug("checkpoint.write", path=str(filepath))
+        os.replace(temppath, str(filepath))
+        logger.debug("checkpoint.atomic_rename", path=str(filepath))
+    except Exception:
+        try:
+            os.unlink(temppath)
+        except OSError:
+            pass
+        raise
 
 
 class Board:
@@ -35,14 +61,14 @@ class Board:
 
     def write_state(self, state: dict) -> None:
         logger.debug("board.write_state", path=str(self.state_path))
-        with open(self.state_path, "w") as f:
+        with _atomic_write(self.state_path) as f:
             json.dump(state, f, indent=2)
 
     def snapshot_state(self, step: int) -> None:
         state = self.read_state()
         path = self.workspace / "history" / f"step_{step:03d}_state.json"
         logger.info("board.snapshot_state", step=step, path=str(path))
-        with open(path, "w") as f:
+        with _atomic_write(path) as f:
             json.dump(state, f, indent=2)
 
     def apply_resolution(self, resolution: Resolution, step: int) -> dict:
@@ -58,25 +84,25 @@ class Board:
 
     def save_proposal(self, proposal: Proposal, step: int) -> Path:
         path = self.workspace / "proposals" / f"step_{step:03d}_{proposal.agent}.json"
-        with open(path, "w") as f:
+        with _atomic_write(path) as f:
             f.write(proposal.model_dump_json(indent=2))
         return path
 
     def save_critique(self, critique: Critique, step: int) -> Path:
         path = self.workspace / "critiques" / f"step_{step:03d}_{critique.agent}.json"
-        with open(path, "w") as f:
+        with _atomic_write(path) as f:
             f.write(critique.model_dump_json(indent=2))
         return path
 
     def save_resolution(self, resolution: Resolution, step: int) -> Path:
         path = self.workspace / "resolutions" / f"step_{step:03d}_resolution.json"
-        with open(path, "w") as f:
+        with _atomic_write(path) as f:
             f.write(resolution.model_dump_json(indent=2))
         return path
 
     def save_step(self, step: Step) -> Path:
         path = self.workspace / "history" / f"step_{step.step_number:03d}_full.json"
-        with open(path, "w") as f:
+        with _atomic_write(path) as f:
             f.write(step.model_dump_json(indent=2))
         return path
 
@@ -99,7 +125,7 @@ class Board:
     def write_wildcard(self, event: WildcardEvent, step: int) -> Path:
         path = self.workspace / "board" / f"wildcard_step_{step:03d}.json"
         logger.info("board.write_wildcard", step=step, wildcard=event.name)
-        with open(path, "w") as f:
+        with _atomic_write(path) as f:
             json.dump(event.model_dump(), f, indent=2)
         return path
 

--- a/src/minimal_agora/loop.py
+++ b/src/minimal_agora/loop.py
@@ -100,6 +100,7 @@ async def run_trajectory(
     trajectory_id: int = 0,
     agent_timeout: int = 300,
 ) -> Trajectory:
+    """Run a single simulation trajectory, returning the completed Trajectory with outcome."""
     board = Board(workspace)
     agent_semaphore = asyncio.Semaphore(scenario.max_concurrent_agents)
 

--- a/src/minimal_agora/loop.py
+++ b/src/minimal_agora/loop.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import random
 from copy import deepcopy
+from datetime import UTC, datetime
 from pathlib import Path
 
 import structlog
@@ -17,7 +18,7 @@ from minimal_agora.agents import (
     parse_proposal,
     parse_resolution,
 )
-from minimal_agora.board import Board, _deep_merge
+from minimal_agora.board import Board, _atomic_write, _deep_merge
 from minimal_agora.models import (
     AgentRole,
     FitnessConfig,
@@ -120,6 +121,9 @@ async def run_trajectory(
     if resume_from > 0:
         tlog.info("trajectory.resume", from_step=resume_from)
         trajectory.steps = _restore_checkpoint(workspace, resume_from, board)
+        trajectory.metadata["resumed"] = True
+        trajectory.metadata["resume_from_step"] = resume_from
+        trajectory.metadata["resume_timestamp"] = datetime.now(UTC).isoformat()
 
     max_steps = scenario.termination.get("max_steps", scenario.step_budget)
     conditions = scenario.termination.get("conditions", [])
@@ -163,9 +167,8 @@ async def run_trajectory(
     final_state = board.read_state()
     final_step = len(trajectory.steps) - 1
 
-    metadata: dict = {}
     if fitness_history:
-        metadata["fitness_history"] = fitness_history
+        trajectory.metadata["fitness_history"] = fitness_history
 
     classification = _classify_outcome(final_state, scenario)
     trajectory.outcome = TrajectoryOutcome(
@@ -173,7 +176,6 @@ async def run_trajectory(
         final_step=final_step,
         final_state=final_state,
     )
-    trajectory.metadata = metadata
 
     _save_trajectory(trajectory, workspace)
     return trajectory
@@ -481,5 +483,5 @@ def _check_plateau(
 
 def _save_trajectory(trajectory: Trajectory, workspace: Path) -> None:
     path = workspace / "trajectory.json"
-    with open(path, "w") as f:
+    with _atomic_write(path) as f:
         f.write(trajectory.model_dump_json(indent=2))

--- a/src/minimal_agora/models.py
+++ b/src/minimal_agora/models.py
@@ -19,6 +19,8 @@ class AgentRole(str, Enum):
 
 
 class AgentConfig(BaseModel):
+    """Configuration for a single LLM agent within a simulation."""
+
     model_config = ConfigDict(extra="forbid")
 
     role: AgentRole
@@ -74,6 +76,8 @@ class InteractionConfig(BaseModel):
 
 
 class EntityConfig(BaseModel):
+    """Configuration for an entity (population, force, critic, or evaluator) in population mode."""
+
     model_config = ConfigDict(extra="forbid")
 
     name: str
@@ -110,6 +114,8 @@ class FitnessConfig(BaseModel):
 
 
 class Scenario(BaseModel):
+    """Top-level simulation scenario defining agents, rules, and termination conditions."""
+
     model_config = ConfigDict(extra="forbid")
 
     name: str
@@ -126,7 +132,7 @@ class Scenario(BaseModel):
     wildcards: list[WildcardEvent] = Field(default_factory=list)
     wildcards_enabled: bool = False
     description: str = ""
-    max_concurrent_agents: int = 8
+    max_concurrent_agents: int = Field(default=8, ge=1)
 
 
 class Proposal(BaseModel):
@@ -186,6 +192,8 @@ class TrajectoryOutcome(BaseModel):
 
 
 class Trajectory(BaseModel):
+    """Record of a single simulation run including steps and final outcome."""
+
     model_config = ConfigDict(extra="forbid")
 
     scenario_name: str

--- a/src/minimal_agora/runner.py
+++ b/src/minimal_agora/runner.py
@@ -14,6 +14,7 @@ async def run_batch(
     concurrency: int = 4,
     agent_timeout: int = 300,
 ) -> list[Trajectory]:
+    """Run multiple trajectories in parallel with bounded concurrency."""
     output_dir.mkdir(parents=True, exist_ok=True)
     n = scenario.n_trajectories
 

--- a/src/minimal_agora/scenario.py
+++ b/src/minimal_agora/scenario.py
@@ -14,6 +14,7 @@ logger = structlog.stdlib.get_logger(__name__)
 
 
 def load_scenario(path: str | Path) -> Scenario:
+    """Load and validate a scenario from a YAML or JSON file."""
     path = Path(path)
     logger.info("scenario.load", path=str(path), format=path.suffix)
     with open(path) as f:

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+
+from minimal_agora.board import Board, _atomic_write
+from minimal_agora.models import (
+    AgentRole,
+    Proposal,
+    Resolution,
+    Scenario,
+    SimMode,
+    Step,
+)
+
+
+def test_atomic_write_produces_correct_content(tmp_path: Path):
+    target = tmp_path / "output.json"
+    data = {"key": "value", "nested": {"a": 1}}
+    with _atomic_write(target) as f:
+        json.dump(data, f, indent=2)
+    assert target.exists()
+    with open(target) as f:
+        assert json.load(f) == data
+
+
+def test_atomic_write_interrupted_leaves_original_intact(tmp_path: Path):
+    target = tmp_path / "state.json"
+    original = {"version": 1}
+    with open(target, "w") as f:
+        json.dump(original, f)
+
+    try:
+        with _atomic_write(target) as f:
+            f.write('{"version": 2, "partial":')
+            raise RuntimeError("simulated crash")
+    except RuntimeError:
+        pass
+
+    with open(target) as f:
+        assert json.load(f) == original
+
+
+def test_atomic_write_no_temp_files_after_success(tmp_path: Path):
+    target = tmp_path / "data.json"
+    with _atomic_write(target) as f:
+        json.dump({"ok": True}, f)
+
+    remaining = list(tmp_path.glob(".tmp_*"))
+    assert remaining == []
+
+
+def test_atomic_write_no_temp_files_after_failure(tmp_path: Path):
+    target = tmp_path / "data.json"
+    try:
+        with _atomic_write(target) as f:
+            f.write("bad")
+            raise ValueError("boom")
+    except ValueError:
+        pass
+
+    remaining = list(tmp_path.glob(".tmp_*"))
+    assert remaining == []
+
+
+def test_board_write_state_uses_atomic(tmp_path: Path):
+    workspace = tmp_path / "ws"
+    board_dir = workspace / "board"
+    board_dir.mkdir(parents=True)
+    (workspace / "history").mkdir()
+    with open(board_dir / "state.json", "w") as f:
+        json.dump({"x": 0}, f)
+
+    board = Board(workspace)
+    board.write_state({"x": 42})
+
+    with open(board_dir / "state.json") as f:
+        assert json.load(f) == {"x": 42}
+    assert list(board_dir.glob(".tmp_*")) == []
+
+
+def test_board_save_step_uses_atomic(tmp_path: Path):
+    workspace = tmp_path / "ws"
+    (workspace / "history").mkdir(parents=True)
+    board = Board(workspace)
+
+    step = Step(step_number=0, state_before={"a": 1}, state_after={"a": 2})
+    path = board.save_step(step)
+    assert path.exists()
+    loaded = Step.model_validate_json(path.read_text())
+    assert loaded.step_number == 0
+    assert list((workspace / "history").glob(".tmp_*")) == []
+
+
+def test_board_save_proposal_uses_atomic(tmp_path: Path):
+    workspace = tmp_path / "ws"
+    (workspace / "proposals").mkdir(parents=True)
+    board = Board(workspace)
+
+    p = Proposal(agent="a", role=AgentRole.ACTOR, proposed_changes={"x": 1})
+    path = board.save_proposal(p, step=0)
+    assert path.exists()
+    assert list((workspace / "proposals").glob(".tmp_*")) == []
+
+
+def test_board_save_resolution_uses_atomic(tmp_path: Path):
+    workspace = tmp_path / "ws"
+    (workspace / "resolutions").mkdir(parents=True)
+    board = Board(workspace)
+
+    r = Resolution(state_delta={"x": 1}, narrative="n", reasoning="r")
+    path = board.save_resolution(r, step=0)
+    assert path.exists()
+    assert list((workspace / "resolutions").glob(".tmp_*")) == []
+
+
+def test_resume_metadata_populated():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "board").mkdir(parents=True)
+        (workspace / "history").mkdir()
+        (workspace / "proposals").mkdir()
+        (workspace / "critiques").mkdir()
+        (workspace / "resolutions").mkdir()
+
+        with open(workspace / "board" / "state.json", "w") as f:
+            json.dump({"x": 0}, f)
+        with open(workspace / "board" / "narrative.md", "w") as f:
+            f.write("# Narrative\n")
+
+        for i in range(3):
+            step = Step(step_number=i, state_before={"x": i}, state_after={"x": i + 1})
+            with open(workspace / "history" / f"step_{i:03d}_full.json", "w") as f:
+                f.write(step.model_dump_json())
+
+        state_at_3 = {"x": 3}
+        with open(workspace / "history" / "step_003_state.json", "w") as f:
+            json.dump(state_at_3, f)
+
+        scenario = Scenario(
+            name="test",
+            mode=SimMode.COUNTERFACTUAL,
+            initial_state={"x": 0},
+            step_budget=3,
+            termination={"max_steps": 3},
+        )
+
+        result = asyncio.run(
+            __import__("minimal_agora.loop", fromlist=["run_trajectory"]).run_trajectory(
+                scenario, workspace, trajectory_id=0,
+            )
+        )
+
+        assert result.metadata.get("resumed") is True
+        assert result.metadata.get("resume_from_step") == 3
+        assert "resume_timestamp" in result.metadata

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,8 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from minimal_agora.analysis import aggregate_outcomes, format_report
 from minimal_agora.board import Board, _deep_merge
 from minimal_agora.models import (
@@ -569,6 +571,17 @@ def test_max_concurrent_agents_configurable():
         max_concurrent_agents=4,
     )
     assert scenario.max_concurrent_agents == 4
+
+
+def test_max_concurrent_agents_rejects_zero():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Scenario(
+            name="test", mode=SimMode.COUNTERFACTUAL,
+            initial_state={"x": 0}, step_budget=5,
+            max_concurrent_agents=0,
+        )
 
 
 def test_convergence_detection():


### PR DESCRIPTION
Closes #7

## Changes

- **Atomic file writes** (`board.py`): Added `_atomic_write()` context manager using `tempfile.mkstemp()` + `os.fsync()` + `os.replace()` for crash-safe writes. Follows the POSIX write-then-rename pattern — files are never left partially written.
- **Board methods hardened**: Replaced all direct file writes in `write_state()`, `save_step()`, `save_proposal()`, `save_critique()`, `save_resolution()`, `write_wildcard()`, and `snapshot_state()` with `_atomic_write`.
- **Trajectory save hardened** (`loop.py`): `_save_trajectory()` now uses `_atomic_write` (imported from board).
- **Resume metadata tracking**: When `resume_from > 0`, trajectory.metadata is populated with `resumed=True`, `resume_from_step`, and `resume_timestamp` (ISO format, UTC).
- **Metadata overwrite fix**: Changed `run_trajectory()` to update `trajectory.metadata` dict in-place instead of replacing it, preserving resume fields alongside fitness_history.
- **Structured logging**: Added `checkpoint.write` and `checkpoint.atomic_rename` debug-level log events for observability.
- **9 new tests**: Atomic write correctness, interrupted write leaves original intact, no temp files after success/failure, board method integration tests, resume metadata population.

All 74 tests pass, ruff clean, mypy clean.