### PR TITLE
Fix: ClaudeSubprocessProvider does not pass tool permissions

### DIFF
--- a/src/minimal_agora/providers/subprocess_provider.py
+++ b/src/minimal_agora/providers/subprocess_provider.py
@@ -21,7 +21,7 @@ class ClaudeSubprocessProvider:
         self.max_turns = max_turns
         self.output_format = output_format
 
-    def build_command(self, prompt: str) -> list[str]:
+    def build_command(self, prompt: str, workspace: Path) -> list[str]:
         return [
             "claude",
             "-p",
@@ -30,6 +30,10 @@ class ClaudeSubprocessProvider:
             self.output_format,
             "--max-turns",
             str(self.max_turns),
+            "--allowedTools",
+            "Read,Write,Bash",
+            "--add-dir",
+            str(workspace),
         ]
 
     async def invoke(
@@ -38,7 +42,7 @@ class ClaudeSubprocessProvider:
         workspace: Path,
         timeout: int = 300,
     ) -> AgentInvocationResult:
-        cmd = self.build_command(prompt)
+        cmd = self.build_command(prompt, workspace)
 
         logger.debug("provider.invoke", provider="claude-subprocess", workspace=str(workspace))
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -64,7 +64,7 @@ class TestMockProvider:
 class TestClaudeSubprocessProvider:
     def test_build_command_defaults(self) -> None:
         provider = ClaudeSubprocessProvider()
-        cmd = provider.build_command("test prompt")
+        cmd = provider.build_command("test prompt", Path("/tmp/workspace"))
         assert cmd == [
             "claude",
             "-p",
@@ -73,15 +73,28 @@ class TestClaudeSubprocessProvider:
             "text",
             "--max-turns",
             "5",
+            "--allowedTools",
+            "Read,Write,Bash",
+            "--add-dir",
+            "/tmp/workspace",
         ]
 
     def test_build_command_custom(self) -> None:
         provider = ClaudeSubprocessProvider(max_turns=10, output_format="json")
-        cmd = provider.build_command("hello")
+        cmd = provider.build_command("hello", Path("/tmp/ws"))
         assert "--max-turns" in cmd
         assert cmd[cmd.index("--max-turns") + 1] == "10"
         assert "--output-format" in cmd
         assert cmd[cmd.index("--output-format") + 1] == "json"
+
+    def test_build_command_includes_tool_permissions(self) -> None:
+        provider = ClaudeSubprocessProvider()
+        workspace = Path("/tmp/test-workspace")
+        cmd = provider.build_command("prompt", workspace)
+        assert "--allowedTools" in cmd
+        assert cmd[cmd.index("--allowedTools") + 1] == "Read,Write,Bash"
+        assert "--add-dir" in cmd
+        assert cmd[cmd.index("--add-dir") + 1] == str(workspace)
 
     def test_satisfies_protocol(self) -> None:
         assert isinstance(ClaudeSubprocessProvider(), AgentProvider)


### PR DESCRIPTION
Closes #19

## Changes

- Changed `build_command()` signature to accept `workspace: Path` parameter
- Added `--allowedTools Read,Write,Bash` flag so agents can use tools in headless mode
- Added `--add-dir <workspace>` flag so file access is scoped to the workspace directory
- Updated `invoke()` to pass workspace through to `build_command()`
- Added test verifying the new flags appear in the generated command
- Updated existing tests for the new `build_command` signature

All 103 tests pass, lint and type checks clean.