### PR TITLE
Add review_interval optimization and fix dotted-path deep-merge bug

### DIFF
--- a/src/minimal_agora/board.py
+++ b/src/minimal_agora/board.py
@@ -74,7 +74,8 @@ class Board:
     def apply_resolution(self, resolution: Resolution, step: int) -> dict:
         logger.info("board.apply_resolution", step=step, delta_keys=list(resolution.state_delta.keys()))
         state = self.read_state()
-        _deep_merge(state, resolution.state_delta)
+        expanded = _expand_dotted_keys(resolution.state_delta)
+        _deep_merge(state, expanded)
         self.write_state(state)
         self.snapshot_state(step + 1)
         self._append_narrative(resolution.narrative, step)
@@ -143,6 +144,27 @@ class Board:
 
     def list_history(self) -> list[Path]:
         return sorted((self.workspace / "history").glob("step_*_state.json"))
+
+
+def _expand_dotted_keys(d: dict) -> dict:
+    result: dict = {}
+    for key, value in d.items():
+        if isinstance(value, dict):
+            value = _expand_dotted_keys(value)
+        if "." in key:
+            parts = key.split(".")
+            current = result
+            for part in parts[:-1]:
+                if part not in current or not isinstance(current[part], dict):
+                    current[part] = {}
+                current = current[part]
+            current[parts[-1]] = value
+        else:
+            if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+                _deep_merge(result[key], value)
+            else:
+                result[key] = value
+    return result
 
 
 def _deep_merge(base: dict, overlay: dict) -> None:

--- a/src/minimal_agora/loop.py
+++ b/src/minimal_agora/loop.py
@@ -18,7 +18,7 @@ from minimal_agora.agents import (
     parse_proposal,
     parse_resolution,
 )
-from minimal_agora.board import Board, _atomic_write, _deep_merge
+from minimal_agora.board import Board, _atomic_write, _deep_merge, _expand_dotted_keys
 from minimal_agora.models import (
     AgentRole,
     FitnessConfig,
@@ -145,7 +145,7 @@ async def run_trajectory(
             slog.info("step.start")
             board.clear_wildcard(step_num)
 
-        step = await _run_step(scenario, board, step_num, agent_timeout, trajectory_id, agent_semaphore)
+        step = await _run_step(scenario, board, step_num, agent_timeout, trajectory_id, agent_semaphore, max_steps)
         trajectory.steps.append(step)
 
         if scenario.fitness:
@@ -188,12 +188,13 @@ async def _run_step(
     timeout: int,
     trajectory_id: int = 0,
     agent_semaphore: asyncio.Semaphore | None = None,
+    max_steps: int = 1,
 ) -> Step:
     state_before = deepcopy(board.read_state())
 
     if scenario.entities:
         return await _run_entity_step(scenario, board, step_num, timeout, state_before, trajectory_id, agent_semaphore)
-    return await _run_flat_step(scenario, board, step_num, timeout, state_before, trajectory_id, agent_semaphore)
+    return await _run_flat_step(scenario, board, step_num, timeout, state_before, trajectory_id, agent_semaphore, max_steps)
 
 
 async def _run_flat_step(
@@ -204,6 +205,7 @@ async def _run_flat_step(
     state_before: dict,
     trajectory_id: int = 0,
     agent_semaphore: asyncio.Semaphore | None = None,
+    max_steps: int = 1,
 ) -> Step:
     actors = [a for a in scenario.agents if a.role == AgentRole.ACTOR]
     critics = [a for a in scenario.agents if a.role == AgentRole.CRITIC]
@@ -232,36 +234,67 @@ async def _run_flat_step(
             proposals.append(p)
             board.save_proposal(p, step_num)
 
+    is_review_step = (
+        scenario.review_interval == 1
+        or (step_num % scenario.review_interval == 0)
+        or (step_num == max_steps - 1)
+    )
+
     critiques = []
-    if critics:
-        critic_tasks = [
-            _invoke_with_semaphore(
-                agent_semaphore, c, board.workspace, step_num,
-                build_prompt(c, step_num, rules), timeout, max_concurrent,
-            ) if agent_semaphore else _invoke_with_retry(
-                c, board.workspace, step_num, build_prompt(c, step_num, rules), timeout,
-            )
-            for c in critics
-        ]
-        await asyncio.gather(*critic_tasks, return_exceptions=True)
-
-        for c in critics:
-            cr = parse_critique(board.workspace, c.name, step_num)
-            if cr:
-                critiques.append(cr)
-                board.save_critique(cr, step_num)
-
     resolution = None
-    if judges:
-        judge = judges[0]
-        await _invoke_with_retry(judge, board.workspace, step_num, build_prompt(judge, step_num, rules), timeout)
-        resolution = parse_resolution(board.workspace, step_num)
 
-    if resolution is None:
-        resolution = _fallback_resolution(proposals)
+    if is_review_step:
+        if critics:
+            critic_tasks = [
+                _invoke_with_semaphore(
+                    agent_semaphore, c, board.workspace, step_num,
+                    build_prompt(c, step_num, rules), timeout, max_concurrent,
+                ) if agent_semaphore else _invoke_with_retry(
+                    c, board.workspace, step_num, build_prompt(c, step_num, rules), timeout,
+                )
+                for c in critics
+            ]
+            await asyncio.gather(*critic_tasks, return_exceptions=True)
 
-    board.save_resolution(resolution, step_num)
-    state_after = board.apply_resolution(resolution, step_num)
+            for c in critics:
+                cr = parse_critique(board.workspace, c.name, step_num)
+                if cr:
+                    critiques.append(cr)
+                    board.save_critique(cr, step_num)
+
+        if judges:
+            judge = judges[0]
+            await _invoke_with_retry(judge, board.workspace, step_num, build_prompt(judge, step_num, rules), timeout)
+            resolution = parse_resolution(board.workspace, step_num)
+
+        if resolution is None:
+            resolution = _fallback_resolution(proposals)
+
+        board.save_resolution(resolution, step_num)
+        state_after = board.apply_resolution(resolution, step_num)
+    else:
+        next_review_step = ((step_num // scenario.review_interval) + 1) * scenario.review_interval
+        logger.debug(
+            "step.auto_merge",
+            step=step_num,
+            n_proposals=len(proposals),
+            next_review_step=next_review_step,
+        )
+
+        merged_state = deepcopy(state_before)
+        for p in proposals:
+            expanded = _expand_dotted_keys(p.proposed_changes)
+            _deep_merge(merged_state, expanded)
+        board.write_state(merged_state)
+        board.snapshot_state(step_num + 1)
+
+        narrative = (
+            f"Step {step_num}: Auto-merged {len(proposals)} actor proposals "
+            f"(review scheduled at step {next_review_step})."
+        )
+        board._append_narrative(narrative, step_num)
+
+        state_after = merged_state
 
     step = Step(
         step_number=step_num,

--- a/src/minimal_agora/models.py
+++ b/src/minimal_agora/models.py
@@ -133,6 +133,7 @@ class Scenario(BaseModel):
     wildcards_enabled: bool = False
     description: str = ""
     max_concurrent_agents: int = Field(default=8, ge=1)
+    review_interval: int = Field(default=1, ge=1)
 
 
 class Proposal(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -608,3 +608,126 @@ def test_convergence_detection():
         for i in range(12)
     ]
     assert detect_convergence(diverse) == []
+
+
+def test_review_interval_default():
+    scenario = Scenario(
+        name="test", mode=SimMode.COUNTERFACTUAL,
+        initial_state={"x": 0}, step_budget=5,
+    )
+    assert scenario.review_interval == 1
+
+
+def test_review_interval_rejects_zero():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Scenario(
+            name="test", mode=SimMode.COUNTERFACTUAL,
+            initial_state={"x": 0}, step_budget=5,
+            review_interval=0,
+        )
+
+
+def test_review_interval_skip():
+    """With review_interval=3 and 4 steps, steps 1 and 2 should be auto-merged (no resolution)."""
+    import asyncio
+
+    from minimal_agora.loop import _run_flat_step
+
+    scenario = Scenario(
+        name="test", mode=SimMode.COUNTERFACTUAL,
+        initial_state={"value": 0},
+        step_budget=4,
+        review_interval=3,
+        agents=[
+            AgentConfig(role=AgentRole.ACTOR, name="actor_a", perspective="test"),
+            AgentConfig(role=AgentRole.CRITIC, name="critic_a", perspective="test"),
+        ],
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        from minimal_agora.scenario import setup_workspace
+
+        workspace = setup_workspace(scenario, Path(tmpdir), trajectory_id=0)
+        board = Board(workspace)
+        semaphore = asyncio.Semaphore(8)
+
+        import minimal_agora.loop as loop_module
+
+        def _write_mock_proposal(agent, workspace, step_num):
+            proposal = Proposal(
+                agent=agent.name, role=AgentRole.ACTOR,
+                proposed_changes={"value": step_num + 1},
+                reasoning="test",
+            )
+            path = workspace / "proposals" / f"step_{step_num:03d}_{agent.name}.json"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w") as f:
+                f.write(proposal.model_dump_json(indent=2))
+
+        async def mock_invoke(agent, workspace, step_num, prompt, timeout, max_retries=1):
+            if agent.role == AgentRole.ACTOR:
+                _write_mock_proposal(agent, workspace, step_num)
+
+        original = loop_module._invoke_with_retry
+        loop_module._invoke_with_retry = mock_invoke
+
+        try:
+            max_steps = 4
+            steps = []
+            for step_num in range(max_steps):
+                state_before = board.read_state()
+                step = asyncio.run(_run_flat_step(
+                    scenario, board, step_num, 60, state_before,
+                    trajectory_id=0, agent_semaphore=semaphore, max_steps=max_steps,
+                ))
+                steps.append(step)
+
+            # Step 0: review step (0 % 3 == 0), has resolution
+            assert steps[0].resolution is not None
+            assert len(steps[0].proposals) == 1
+
+            # Steps 1 and 2: auto-merged, no resolution
+            assert steps[1].resolution is None
+            assert steps[1].critiques == []
+            assert len(steps[1].proposals) == 1
+
+            assert steps[2].resolution is None
+            assert steps[2].critiques == []
+
+            # Step 3: last step, always reviewed, has resolution
+            assert steps[3].resolution is not None
+        finally:
+            loop_module._invoke_with_retry = original
+
+
+def test_expand_dotted_keys():
+    from minimal_agora.board import _expand_dotted_keys
+
+    result = _expand_dotted_keys({"a.b.c": 1, "a.b.d": 2, "x": 3})
+    assert result == {"a": {"b": {"c": 1, "d": 2}}, "x": 3}
+
+
+def test_expand_dotted_keys_no_dots():
+    from minimal_agora.board import _expand_dotted_keys
+
+    result = _expand_dotted_keys({"a": 1, "b": {"c": 2}})
+    assert result == {"a": 1, "b": {"c": 2}}
+
+
+def test_apply_resolution_with_dotted_paths():
+    scenario = load_scenario(EXAMPLES_DIR / "intelligence.yaml")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = setup_workspace(scenario, Path(tmpdir), trajectory_id=0)
+        board = Board(workspace)
+
+        resolution = Resolution(
+            state_delta={"life.photosynthesis": True, "environment.biodiversity": "high"},
+            narrative="Dotted path test.",
+            reasoning="Testing dotted key expansion.",
+        )
+
+        state_after = board.apply_resolution(resolution, step=0)
+        assert state_after["life"]["photosynthesis"] is True
+        assert state_after["environment"]["biodiversity"] == "high"


### PR DESCRIPTION
## Changes

- **Review interval (efficiency optimization):** Added `review_interval` field to `Scenario` (default=1, backward compatible). When set to N > 1, only every Nth step runs the full critic/judge pipeline — intermediate steps auto-merge actor proposals directly into state. The last step always gets a full review regardless.
- **Dotted-path deep-merge fix:** Added `_expand_dotted_keys()` helper in `board.py` that expands keys like `'planet.climate'` into nested dicts (`{'planet': {'climate': ...}}`). `apply_resolution()` now expands dotted keys before deep-merging, fixing the bug where dotted-path state deltas were stored as flat keys.
- **Tests:** 6 new tests covering review_interval default/validation/skip behavior, dotted key expansion, and dotted-path resolution application.

All 109 tests pass, ruff clean, mypy clean.