### PR TITLE
Add particle filtering / sequential importance resampling for trajectories

### DIFF
--- a/scenarios/examples/democracy.yaml
+++ b/scenarios/examples/democracy.yaml
@@ -183,6 +183,20 @@ wildcards:
       world:
         trade_connectivity: "disrupted"
 
+resampling:
+  interval: 3
+  criteria:
+    - 'Did a new political faction or movement emerge?'
+    - 'Did power dynamics shift significantly?'
+    - 'Is there meaningful ideological conflict?'
+    - 'Did public opinion change on a key issue?'
+    - 'Was there institutional reform or constitutional change?'
+    - 'Did an external crisis affect domestic politics?'
+    - 'Are there coalition dynamics creating unexpected alliances?'
+    - 'Is democratic participation increasing or decreasing?'
+    - 'Did a leader or movement gain or lose legitimacy?'
+    - 'Are there tensions between democratic norms and political realities?'
+
 termination:
   max_steps: 1000
   conditions:

--- a/scenarios/examples/intelligence.yaml
+++ b/scenarios/examples/intelligence.yaml
@@ -187,6 +187,20 @@ wildcards:
       environment:
         biodiversity: "minimal"
 
+resampling:
+  interval: 5
+  criteria:
+    - 'Did biological complexity increase this period?'
+    - 'Did a novel metabolic pathway or energy strategy emerge?'
+    - 'Did a mass extinction create new ecological opportunities?'
+    - 'Is there meaningful competition between life forms?'
+    - 'Did the environment change in ways that create new selection pressures?'
+    - 'Are there surprising or non-obvious interactions between systems?'
+    - 'Is this trajectory on a unique evolutionary path?'
+    - 'Did a key innovation occur (photosynthesis, multicellularity, nervous system)?'
+    - 'Is biodiversity trending upward?'
+    - 'Are there unresolved tensions that could drive future change?'
+
 termination:
   max_steps: 500
   conditions:

--- a/src/minimal_agora/agents.py
+++ b/src/minimal_agora/agents.py
@@ -10,6 +10,7 @@ from minimal_agora.models import (
     Critique,
     EntityConfig,
     Proposal,
+    ResamplingScore,
     Resolution,
     SimRule,
 )
@@ -320,4 +321,51 @@ def parse_resolution(workspace: Path, step: int) -> Resolution | None:
             return Resolution.model_validate_json(f.read())
     except (ValueError, OSError, KeyError) as e:
         logger.warning("Failed to parse resolution %s: %s", path.name, e)
+        return None
+
+
+def build_resampling_critic_prompt(criteria: list[str], step: int) -> str:
+    criteria_lines = "\n".join(f"{i + 1}. {c}" for i, c in enumerate(criteria))
+    return f"""You are a **resampling critic** evaluating trajectory quality at step {step}.
+
+## Instructions
+1. Read the current world state from `board/state.json`
+2. Read the narrative history from `board/narrative.md`
+3. For each criterion below, score 0 (no) or 1 (yes):
+
+{criteria_lines}
+
+4. Write your result as a JSON file to `critiques/resample_step_{step:03d}.json`
+
+The JSON must have this structure:
+```json
+{{
+  "scores": [0, 1, 1, ...],
+  "total": 4,
+  "notes": "Brief explanation of your scoring"
+}}
+```
+
+The `scores` array must have exactly {len(criteria)} elements (one per criterion above).
+The `total` must equal the sum of the scores array.
+"""
+
+
+def parse_resampling_score(workspace: Path, step: int, trajectory_id: int) -> ResamplingScore | None:
+    path = workspace / "critiques" / f"resample_step_{step:03d}.json"
+    if not path.exists():
+        logger.warning("Resampling score file missing: %s", path)
+        return None
+    try:
+        import json
+        with open(path) as f:
+            data = json.load(f)
+        return ResamplingScore(
+            trajectory_id=trajectory_id,
+            scores=data["scores"],
+            total=data["total"],
+            notes=data.get("notes", ""),
+        )
+    except (ValueError, OSError, KeyError) as e:
+        logger.warning("Failed to parse resampling score %s: %s", path.name, e)
         return None

--- a/src/minimal_agora/cli.py
+++ b/src/minimal_agora/cli.py
@@ -15,7 +15,7 @@ from minimal_agora.analysis import (
     save_report,
 )
 from minimal_agora.logging_config import configure_logging
-from minimal_agora.runner import run_batch
+from minimal_agora.runner import run_batch, run_particle_filter
 from minimal_agora.scenario import load_scenario
 
 
@@ -142,9 +142,14 @@ def cmd_run(args) -> int:
         print("\nDry run complete. Scenario is valid.")
         return 0
 
-    trajectories = asyncio.run(
-        run_batch(scenario, output_dir, args.concurrency, args.timeout)
-    )
+    if scenario.resampling:
+        trajectories = asyncio.run(
+            run_particle_filter(scenario, output_dir, args.concurrency, args.timeout)
+        )
+    else:
+        trajectories = asyncio.run(
+            run_batch(scenario, output_dir, args.concurrency, args.timeout)
+        )
 
     question = scenario.outcome.question if scenario.outcome else ""
     result = aggregate_outcomes(trajectories, question)

--- a/src/minimal_agora/models.py
+++ b/src/minimal_agora/models.py
@@ -113,6 +113,37 @@ class FitnessConfig(BaseModel):
     direction: str = "maximize"
 
 
+class ResamplingConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    interval: int = Field(default=5, ge=1)
+    criteria: list[str] = Field(default_factory=list)
+    min_particles: int = Field(default=2, ge=1)
+
+
+class ResamplingScore(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    trajectory_id: int
+    scores: list[int]
+    total: int
+    notes: str = ""
+
+
+DEFAULT_RESAMPLING_CRITERIA = [
+    "Did the system state change meaningfully this period?",
+    "Did a novel entity, force, or dynamic emerge?",
+    "Is there active conflict or tension between forces?",
+    "Did complexity increase (new structures, relationships, or hierarchies)?",
+    "Did an unexpected or surprising event occur?",
+    "Are there unresolved tensions that could drive future change?",
+    "Is this trajectory exploring a unique path compared to the initial state?",
+    "Did the environment or external conditions change significantly?",
+    "Are there second-order effects or cascading consequences unfolding?",
+    "Would continuing this trajectory likely produce new information?",
+]
+
+
 class Scenario(BaseModel):
     """Top-level simulation scenario defining agents, rules, and termination conditions."""
 
@@ -134,6 +165,7 @@ class Scenario(BaseModel):
     description: str = ""
     max_concurrent_agents: int = Field(default=8, ge=1)
     review_interval: int = Field(default=1, ge=1)
+    resampling: ResamplingConfig | None = None
 
 
 class Proposal(BaseModel):

--- a/src/minimal_agora/resampling.py
+++ b/src/minimal_agora/resampling.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+
+import structlog
+
+from minimal_agora.agents import (
+    build_resampling_critic_prompt,
+    invoke_agent,
+    parse_resampling_score,
+)
+from minimal_agora.models import (
+    DEFAULT_RESAMPLING_CRITERIA,
+    AgentConfig,
+    AgentRole,
+    ResamplingScore,
+    Scenario,
+)
+
+logger = structlog.stdlib.get_logger(__name__)
+
+
+def systematic_resample(weights: list[float], n: int) -> list[int]:
+    cumsum = []
+    running = 0.0
+    for w in weights:
+        running += w
+        cumsum.append(running)
+
+    step = 1.0 / n
+    u = step * 0.5
+    indices = []
+    i = 0
+    for _ in range(n):
+        while i < len(cumsum) - 1 and u > cumsum[i]:
+            i += 1
+        indices.append(i)
+        u += step
+    return indices
+
+
+def compute_weights(scores: list[ResamplingScore]) -> list[float]:
+    raw = [s.total + 1 for s in scores]
+    total = sum(raw)
+    return [r / total for r in raw]
+
+
+def fork_workspace(src_workspace: Path, dst_workspace: Path) -> None:
+    if dst_workspace.exists():
+        shutil.rmtree(dst_workspace)
+    shutil.copytree(src_workspace, dst_workspace)
+
+
+async def resample_particles(
+    scenario: Scenario,
+    workspaces: list[Path],
+    step: int,
+    agent_timeout: int,
+    agent_semaphore: asyncio.Semaphore | None,
+) -> list[Path]:
+    resample_cfg = scenario.resampling
+    if resample_cfg is None:
+        return workspaces
+
+    criteria = resample_cfg.criteria or DEFAULT_RESAMPLING_CRITERIA
+    n = len(workspaces)
+
+    critic_agent = AgentConfig(
+        role=AgentRole.CRITIC,
+        name="resampling_critic",
+        perspective="You evaluate trajectory quality for resampling.",
+    )
+    prompt = build_resampling_critic_prompt(criteria, step)
+
+    async def run_critic(idx: int) -> None:
+        ws = workspaces[idx]
+        (ws / "critiques").mkdir(parents=True, exist_ok=True)
+        if agent_semaphore:
+            async with agent_semaphore:
+                await invoke_agent(critic_agent, ws, step, prompt, agent_timeout)
+        else:
+            await invoke_agent(critic_agent, ws, step, prompt, agent_timeout)
+
+    await asyncio.gather(*[run_critic(i) for i in range(n)], return_exceptions=True)
+
+    scores: list[ResamplingScore] = []
+    for i in range(n):
+        score = parse_resampling_score(workspaces[i], step, trajectory_id=i)
+        if score is None:
+            score = ResamplingScore(trajectory_id=i, scores=[0] * len(criteria), total=0)
+        scores.append(score)
+
+    weights = compute_weights(scores)
+    parent_indices = systematic_resample(weights, n)
+
+    n_killed = len(set(range(n)) - set(parent_indices))
+    n_forked = len(parent_indices) - len(set(parent_indices))
+
+    new_workspaces = list(workspaces)
+    for dst_idx in range(n):
+        src_idx = parent_indices[dst_idx]
+        if src_idx != dst_idx:
+            fork_workspace(workspaces[src_idx], workspaces[dst_idx])
+            new_workspaces[dst_idx] = workspaces[dst_idx]
+
+    logger.info(
+        "resample.complete",
+        step=step,
+        n_killed=n_killed,
+        n_forked=n_forked,
+        weights=[round(w, 4) for w in weights],
+        scores=[s.total for s in scores],
+    )
+
+    return new_workspaces

--- a/src/minimal_agora/runner.py
+++ b/src/minimal_agora/runner.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 from pathlib import Path
 
-from minimal_agora.loop import run_trajectory
-from minimal_agora.models import Scenario, Trajectory
+import structlog
+
+from minimal_agora.board import Board, _deep_merge
+from minimal_agora.loop import (
+    _classify_outcome,
+    _roll_wildcard,
+    _run_flat_step,
+    run_trajectory,
+)
+from minimal_agora.models import (
+    Scenario,
+    Step,
+    Trajectory,
+    TrajectoryOutcome,
+)
+from minimal_agora.resampling import resample_particles
 from minimal_agora.scenario import setup_workspace
+
+logger = structlog.stdlib.get_logger(__name__)
 
 
 async def run_batch(
@@ -43,3 +60,81 @@ async def run_batch(
         print(f"[batch] {skipped}/{n} trajectories resumed from checkpoint")
 
     return results
+
+
+async def run_particle_filter(
+    scenario: Scenario,
+    output_dir: Path,
+    concurrency: int = 4,
+    agent_timeout: int = 300,
+) -> list[Trajectory]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    n = scenario.n_trajectories
+    resample_cfg = scenario.resampling
+    if resample_cfg is None:
+        return await run_batch(scenario, output_dir, concurrency, agent_timeout)
+
+    max_steps = scenario.termination.get("max_steps", scenario.step_budget)
+    semaphore = asyncio.Semaphore(concurrency)
+    agent_sem = asyncio.Semaphore(scenario.max_concurrent_agents)
+
+    workspaces = [setup_workspace(scenario, output_dir, i) for i in range(n)]
+    boards = [Board(ws) for ws in workspaces]
+    all_steps: list[list[Step]] = [[] for _ in range(n)]
+
+    for step_num in range(max_steps):
+        for i in range(n):
+            if scenario.wildcards_enabled:
+                wildcard = _roll_wildcard(scenario.wildcards, max_steps)
+                if wildcard:
+                    boards[i].write_wildcard(wildcard, step_num)
+                    if wildcard.state_impact:
+                        state = boards[i].read_state()
+                        _deep_merge(state, wildcard.state_impact)
+                        boards[i].write_state(state)
+                else:
+                    boards[i].clear_wildcard(step_num)
+
+        is_last = step_num == max_steps - 1
+
+        async def run_one_step(idx: int, _boards=boards, _step_num=step_num) -> None:
+            async with semaphore:
+                state_before = deepcopy(_boards[idx].read_state())
+                step = await _run_flat_step(
+                    scenario, _boards[idx], _step_num, agent_timeout,
+                    state_before, trajectory_id=idx,
+                    agent_semaphore=agent_sem, max_steps=max_steps,
+                )
+                all_steps[idx].append(step)
+
+        await asyncio.gather(*[run_one_step(i) for i in range(n)], return_exceptions=True)
+
+        if (
+            step_num > 0
+            and step_num % resample_cfg.interval == 0
+            and not is_last
+            and n > resample_cfg.min_particles
+        ):
+            workspaces = await resample_particles(
+                scenario, workspaces, step_num, agent_timeout, agent_sem,
+            )
+            boards = [Board(ws) for ws in workspaces]
+
+    trajectories = []
+    for i in range(n):
+        final_state = boards[i].read_state()
+        final_step = len(all_steps[i]) - 1
+        classification = _classify_outcome(final_state, scenario)
+        traj = Trajectory(
+            scenario_name=scenario.name,
+            trajectory_id=i,
+            steps=all_steps[i],
+            outcome=TrajectoryOutcome(
+                classification=classification,
+                final_step=final_step,
+                final_state=final_state,
+            ),
+        )
+        trajectories.append(traj)
+
+    return trajectories

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -1,0 +1,142 @@
+import json
+import tempfile
+from pathlib import Path
+
+from minimal_agora.agents import build_resampling_critic_prompt, parse_resampling_score
+from minimal_agora.models import (
+    DEFAULT_RESAMPLING_CRITERIA,
+    ResamplingConfig,
+    ResamplingScore,
+    Scenario,
+    SimMode,
+)
+from minimal_agora.resampling import compute_weights, fork_workspace, systematic_resample
+
+
+def test_resampling_config_default():
+    cfg = ResamplingConfig()
+    assert cfg.interval == 5
+    assert cfg.criteria == []
+    assert cfg.min_particles == 2
+
+
+def test_scenario_resampling_none_by_default():
+    scenario = Scenario(
+        name="test", mode=SimMode.COUNTERFACTUAL,
+        initial_state={"x": 0}, step_budget=5,
+    )
+    assert scenario.resampling is None
+
+
+def test_scenario_with_resampling():
+    scenario = Scenario(
+        name="test", mode=SimMode.COUNTERFACTUAL,
+        initial_state={"x": 0}, step_budget=5,
+        resampling=ResamplingConfig(interval=3, criteria=["Is it good?"]),
+    )
+    assert scenario.resampling is not None
+    assert scenario.resampling.interval == 3
+    assert scenario.resampling.criteria == ["Is it good?"]
+
+
+def test_systematic_resample():
+    weights = [0.5, 0.3, 0.1, 0.1]
+    indices = systematic_resample(weights, 4)
+    assert len(indices) == 4
+    assert all(0 <= i < 4 for i in indices)
+    assert indices.count(0) >= indices.count(3)
+
+
+def test_compute_weights_laplace():
+    scores = [
+        ResamplingScore(trajectory_id=0, scores=[0, 0, 0], total=0),
+        ResamplingScore(trajectory_id=1, scores=[0, 0, 0], total=0),
+        ResamplingScore(trajectory_id=2, scores=[0, 0, 0], total=0),
+    ]
+    weights = compute_weights(scores)
+    assert len(weights) == 3
+    assert all(w > 0 for w in weights)
+    assert abs(sum(weights) - 1.0) < 1e-9
+    assert all(abs(w - 1 / 3) < 1e-9 for w in weights)
+
+
+def test_compute_weights_normal():
+    scores = [
+        ResamplingScore(trajectory_id=0, scores=[1] * 10, total=10),
+        ResamplingScore(trajectory_id=1, scores=[1] * 5, total=5),
+        ResamplingScore(trajectory_id=2, scores=[], total=0),
+    ]
+    weights = compute_weights(scores)
+    assert abs(sum(weights) - 1.0) < 1e-9
+    assert abs(weights[0] - 11 / 18) < 1e-9
+    assert abs(weights[1] - 6 / 18) < 1e-9
+    assert abs(weights[2] - 1 / 18) < 1e-9
+
+
+def test_fork_workspace():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src = Path(tmpdir) / "src_ws"
+        dst = Path(tmpdir) / "dst_ws"
+        src.mkdir()
+        (src / "board").mkdir()
+        (src / "board" / "state.json").write_text('{"x": 1}')
+        (src / "narrative.md").write_text("# Log")
+
+        fork_workspace(src, dst)
+
+        assert dst.exists()
+        assert (dst / "board" / "state.json").exists()
+        assert json.loads((dst / "board" / "state.json").read_text()) == {"x": 1}
+        assert (dst / "narrative.md").read_text() == "# Log"
+
+
+def test_build_resampling_critic_prompt():
+    criteria = ["Criterion A?", "Criterion B?", "Criterion C?"]
+    prompt = build_resampling_critic_prompt(criteria, step=5)
+    for c in criteria:
+        assert c in prompt
+    assert "step 5" in prompt
+    assert "resample_step_005.json" in prompt
+    assert "exactly 3 elements" in prompt
+
+
+def test_default_criteria_used():
+    cfg = ResamplingConfig()
+    criteria = cfg.criteria or DEFAULT_RESAMPLING_CRITERIA
+    assert len(criteria) == 10
+    assert criteria is DEFAULT_RESAMPLING_CRITERIA
+
+
+def test_parse_resampling_score():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        critiques = workspace / "critiques"
+        critiques.mkdir()
+        data = {"scores": [1, 0, 1, 1], "total": 3, "notes": "test"}
+        (critiques / "resample_step_005.json").write_text(json.dumps(data))
+        score = parse_resampling_score(workspace, step=5, trajectory_id=2)
+        assert score is not None
+        assert score.trajectory_id == 2
+        assert score.scores == [1, 0, 1, 1]
+        assert score.total == 3
+        assert score.notes == "test"
+
+
+def test_parse_resampling_score_missing():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "critiques").mkdir()
+        score = parse_resampling_score(workspace, step=5, trajectory_id=0)
+        assert score is None
+
+
+def test_systematic_resample_uniform():
+    weights = [0.25, 0.25, 0.25, 0.25]
+    indices = systematic_resample(weights, 4)
+    assert sorted(indices) == [0, 1, 2, 3]
+
+
+def test_systematic_resample_degenerate():
+    weights = [1.0, 0.0, 0.0]
+    indices = systematic_resample(weights, 3)
+    assert all(i == 0 for i in indices)


### PR DESCRIPTION
Closes #N/A (requested directly)

## Changes

- **Models** (`models.py`): Added `ResamplingConfig` (interval, criteria, min_particles), `ResamplingScore` (per-trajectory scoring), and `DEFAULT_RESAMPLING_CRITERIA` (10 generic fallback criteria)
- **Agents** (`agents.py`): Added `build_resampling_critic_prompt()` — instructs an LLM critic to binary-score each criterion — and `parse_resampling_score()` to read back the JSON result
- **Resampling module** (`resampling.py` — new): `systematic_resample()` (standard SIR algorithm), `compute_weights()` (Laplace-smoothed normalization), `fork_workspace()` (copy high-weight trajectory to replace low-weight), `resample_particles()` (orchestrates critic scoring → weight computation → resampling → workspace forking)
- **Runner** (`runner.py`): Added `run_particle_filter()` — step-synchronized runner that drives all N particles one step at a time, resampling at configurable intervals via `resample_particles()`
- **CLI** (`cli.py`): Routes to `run_particle_filter` when `scenario.resampling` is set, falls back to `run_batch` otherwise
- **Scenarios**: Added `resampling` config blocks to `intelligence.yaml` (interval=5) and `democracy.yaml` (interval=3) with domain-specific criteria
- **Tests** (`test_resampling.py`): 13 tests covering config defaults, scenario parsing, systematic resampling, weight computation (Laplace smoothing), workspace forking, prompt building, score parsing, and edge cases

Backward compatible — scenarios without a `resampling` field work exactly as before.