### PR TITLE
UX polish: error handling for CLI edge cases

### DIFF
--- a/src/minimal_agora/cli.py
+++ b/src/minimal_agora/cli.py
@@ -57,6 +57,7 @@ def main() -> int:
     init_parser = subparsers.add_parser("init-scenario", help="Generate a template scenario YAML file")
     init_parser.add_argument("name", help="Scenario name")
     init_parser.add_argument("--mode", choices=["counterfactual", "open_ended", "population"], default="counterfactual", help="Simulation mode")
+    init_parser.add_argument("--force", action="store_true", help="Overwrite existing file")
 
     agents_parser = subparsers.add_parser("agents", help="List agents/entities from a scenario")
     agents_parser.add_argument("scenario", type=Path, help="Path to scenario YAML/JSON")
@@ -100,6 +101,10 @@ def main() -> int:
 
 def cmd_run(args) -> int:
     from minimal_agora.models import SimMode
+
+    if not args.scenario.exists():
+        print(f"Scenario file not found: {args.scenario}")
+        return 1
 
     scenario = load_scenario(args.scenario)
 
@@ -211,10 +216,18 @@ def cmd_dashboard(args) -> int:
 
 
 def cmd_validate(args) -> int:
+    from pydantic import ValidationError
+
     try:
         load_scenario(args.scenario)
         print("Valid")
         return 0
+    except ValidationError as e:
+        print("Invalid scenario:")
+        for err in e.errors():
+            loc = " → ".join(str(l) for l in err["loc"])
+            print(f"  {loc}: {err['msg']}")
+        return 1
     except (OSError, ValueError, KeyError) as e:
         print(f"Invalid: {e}")
         return 1
@@ -280,7 +293,12 @@ def cmd_init_scenario(args) -> int:
     import yaml
 
     filename = f"{name}.yaml"
-    with open(filename, "w") as f:
+    filepath = Path(filename)
+    if filepath.exists() and not args.force:
+        print(f"File already exists: {filepath}. Use --force to overwrite.")
+        return 1
+
+    with open(filepath, "w") as f:
         yaml.dump(template, f, default_flow_style=False, sort_keys=False)
 
     print(f"Created scenario template: {filename}")
@@ -288,6 +306,10 @@ def cmd_init_scenario(args) -> int:
 
 
 def cmd_agents(args) -> int:
+    if not args.scenario.exists():
+        print(f"Scenario file not found: {args.scenario}")
+        return 1
+
     scenario = load_scenario(args.scenario)
 
     if scenario.agents:

--- a/tests/test_cli_api.py
+++ b/tests/test_cli_api.py
@@ -139,6 +139,63 @@ def test_dry_run_population():
     assert "Entities:" in result.stdout
 
 
+def test_validate_invalid_yaml_friendly_error():
+    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
+        yaml.dump({"name": "bad", "mode": "counterfactual"}, f)
+        f.flush()
+        result = _run_cli("validate", f.name)
+    assert result.returncode == 1
+    assert "Invalid scenario:" in result.stdout
+    assert "initial_state" in result.stdout
+    assert "Field required" in result.stdout
+
+
+def test_init_scenario_no_overwrite():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        existing = Path(tmpdir) / "existing.yaml"
+        existing.write_text("placeholder")
+        result = subprocess.run(
+            [sys.executable, "-m", "minimal_agora.cli", "init-scenario", "existing"],
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "File already exists" in result.stdout
+        assert "--force" in result.stdout
+        assert existing.read_text() == "placeholder"
+
+
+def test_init_scenario_force():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        existing = Path(tmpdir) / "forced.yaml"
+        existing.write_text("placeholder")
+        result = subprocess.run(
+            [sys.executable, "-m", "minimal_agora.cli", "init-scenario", "forced", "--force"],
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+            check=False,
+        )
+        assert result.returncode == 0
+        assert "Created scenario template" in result.stdout
+        data = yaml.safe_load(existing.read_text())
+        assert data["name"] == "forced"
+
+
+def test_agents_missing_file():
+    result = _run_cli("agents", "/tmp/nonexistent_scenario_xyz.yaml")
+    assert result.returncode == 1
+    assert "Scenario file not found" in result.stdout
+
+
+def test_run_missing_scenario():
+    result = _run_cli("run", "/tmp/nonexistent_scenario_xyz.yaml")
+    assert result.returncode == 1
+    assert "Scenario file not found" in result.stdout
+
+
 def test_report_json_format():
     from minimal_agora.models import Trajectory, TrajectoryOutcome
 


### PR DESCRIPTION
Closes #16

## Changes

- **validate subcommand**: Catches `pydantic.ValidationError` separately and prints a user-friendly per-field summary (field path + message) instead of a raw traceback
- **init-scenario**: Checks if the output file already exists before writing; prints `File already exists: <path>. Use --force to overwrite.` and exits 1. Added `--force` flag to bypass
- **agents subcommand**: Checks scenario file exists before loading; prints `Scenario file not found: <path>` instead of a `FileNotFoundError` traceback
- **run subcommand**: Validates scenario file exists before starting; prints `Scenario file not found: <path>` and exits 1

## Tests added

- `test_validate_invalid_yaml_friendly_error` — validate with incomplete YAML shows clean field-level errors
- `test_init_scenario_no_overwrite` — init-scenario refuses to overwrite existing file
- `test_init_scenario_force` — init-scenario --force overwrites successfully
- `test_agents_missing_file` — agents with nonexistent path gives clean error
- `test_run_missing_scenario` — run with nonexistent path gives clean error

All 131 tests pass, ruff clean, mypy clean.