### PR TITLE
Update gitignore, add observability logging, migrate to TaskGroup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,15 @@ __pycache__/
 .pytest_cache/
 runs/
 _references/
+.coverage
+.factory/
+.factory-worktrees/
+*.egg-info/
+dist/
+build/
+.mypy_cache/
+.ruff_cache/
+htmlcov/
+.venv/
+*.env
+skills/

--- a/src/minimal_agora/agents.py
+++ b/src/minimal_agora/agents.py
@@ -158,6 +158,13 @@ def _diversity_prefix(trajectory_id: int) -> str:
 
 
 def build_actor_prompt(agent: AgentConfig, step: int, rules: list[SimRule] | None = None, interaction_context: str = "", trajectory_id: int | None = None) -> str:
+    logger.debug(
+        "prompt.build_actor",
+        agent=agent.name,
+        step=step,
+        has_wildcard=True,
+        has_interaction_context=bool(interaction_context),
+    )
     rules_block = _format_rules(rules or [], agent.name, agent.role.value)
     interaction_block = f"\n{interaction_context}\n" if interaction_context else ""
     diversity_block = f"\n{_diversity_prefix(trajectory_id)}\n" if trajectory_id is not None else ""
@@ -201,6 +208,7 @@ of state.json. Only include fields you want to change.
 
 
 def build_critic_prompt(agent: AgentConfig, step: int, rules: list[SimRule] | None = None) -> str:
+    logger.debug("prompt.build_critic", agent=agent.name, step=step)
     rules_block = _format_rules(rules or [], agent.name, agent.role.value)
     return f"""You are **{agent.name}**, a critic agent in a world simulation.
 
@@ -235,6 +243,7 @@ The JSON must have this structure:
 
 
 def build_judge_prompt(agent: AgentConfig, step: int, rules: list[SimRule] | None = None) -> str:
+    logger.debug("prompt.build_judge", agent=agent.name, step=step)
     rules_block = _format_rules(rules or [], agent.name, agent.role.value)
     return f"""You are **{agent.name}**, the judge agent in a world simulation.
 
@@ -292,7 +301,9 @@ def parse_proposal(workspace: Path, agent_name: str, step: int) -> Proposal | No
         return None
     try:
         with open(path) as f:
-            return Proposal.model_validate_json(f.read())
+            result = Proposal.model_validate_json(f.read())
+        logger.debug("parse.proposal.success", agent_name=agent_name, step=step)
+        return result
     except (ValueError, OSError, KeyError) as e:
         logger.warning("Failed to parse proposal %s: %s", path.name, e)
         return None
@@ -305,7 +316,9 @@ def parse_critique(workspace: Path, agent_name: str, step: int) -> Critique | No
         return None
     try:
         with open(path) as f:
-            return Critique.model_validate_json(f.read())
+            result = Critique.model_validate_json(f.read())
+        logger.debug("parse.critique.success", agent_name=agent_name, step=step)
+        return result
     except (ValueError, OSError, KeyError) as e:
         logger.warning("Failed to parse critique %s: %s", path.name, e)
         return None
@@ -318,7 +331,9 @@ def parse_resolution(workspace: Path, step: int) -> Resolution | None:
         return None
     try:
         with open(path) as f:
-            return Resolution.model_validate_json(f.read())
+            result = Resolution.model_validate_json(f.read())
+        logger.debug("parse.resolution.success", step=step)
+        return result
     except (ValueError, OSError, KeyError) as e:
         logger.warning("Failed to parse resolution %s: %s", path.name, e)
         return None

--- a/src/minimal_agora/analysis.py
+++ b/src/minimal_agora/analysis.py
@@ -80,6 +80,7 @@ def extract_field_timelines(
 
 
 def compute_statistics(values: Sequence[float | int]) -> dict[str, float]:
+    logger.debug("analysis.compute_statistics", n_values=len(values))
     if not values:
         return {}
     n = len(values)
@@ -292,7 +293,9 @@ def cohens_d(
     else:
         d_val = (mean_a - mean_b) / pooled_std
 
-    return {"d": d_val, "interpretation": _interpret_cohens_d(d_val)}
+    interpretation = _interpret_cohens_d(d_val)
+    logger.debug("analysis.cohens_d", effect_size=d_val, interpretation=interpretation)
+    return {"d": d_val, "interpretation": interpretation}
 
 
 def compare_runs(
@@ -304,6 +307,13 @@ def compare_runs(
 ) -> CrossRunComparison:
     n_a = len(trajectories_a)
     n_b = len(trajectories_b)
+    logger.info(
+        "analysis.compare_runs",
+        run_a=name_a,
+        run_b=name_b,
+        n_trajectories_a=n_a,
+        n_trajectories_b=n_b,
+    )
 
     counts_a: dict[str, int] = defaultdict(int)
     counts_b: dict[str, int] = defaultdict(int)
@@ -368,6 +378,7 @@ def compare_runs(
             f"{name_a} (n={n_a}) and {name_b} (n={n_b}) at alpha={alpha}."
         )
 
+    logger.info("analysis.compare_runs.done", n_significant_differences=len(sig_diffs))
     return CrossRunComparison(
         run_a_name=name_a,
         run_b_name=name_b,

--- a/src/minimal_agora/loop.py
+++ b/src/minimal_agora/loop.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import random
+import time
 from copy import deepcopy
 from datetime import UTC, datetime
 from pathlib import Path
@@ -31,6 +32,13 @@ from minimal_agora.models import (
     TrajectoryType,
     WildcardEvent,
 )
+
+
+async def _safe_invoke(coro) -> None:
+    try:
+        await coro
+    except Exception as e:  # noqa: BLE001
+        logger.warning("agent.task_failed", error=str(e))
 
 
 async def _invoke_with_retry(
@@ -213,19 +221,28 @@ async def _run_flat_step(
 
     max_concurrent = scenario.max_concurrent_agents
     rules = scenario.rules
-    actor_tasks = [
-        _invoke_with_semaphore(
-            agent_semaphore, a, board.workspace, step_num,
-            build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
-            timeout, max_concurrent,
-        ) if agent_semaphore else _invoke_with_retry(
-            a, board.workspace, step_num,
-            build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
-            timeout,
-        )
-        for a in actors
-    ]
-    await asyncio.gather(*actor_tasks, return_exceptions=True)
+
+    logger.debug("flat_step.propose_start", step=step_num, n_actors=len(actors))
+    t0 = time.monotonic()
+    try:
+        async with asyncio.TaskGroup() as tg:
+            for a in actors:
+                coro = (
+                    _invoke_with_semaphore(
+                        agent_semaphore, a, board.workspace, step_num,
+                        build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
+                        timeout, max_concurrent,
+                    ) if agent_semaphore else _invoke_with_retry(
+                        a, board.workspace, step_num,
+                        build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
+                        timeout,
+                    )
+                )
+                tg.create_task(_safe_invoke(coro))
+    except ExceptionGroup as eg:
+        for exc in eg.exceptions:
+            logger.error("flat_step.propose.unhandled_failure", step=step_num, error=str(exc))
+    logger.debug("flat_step.propose_done", step=step_num, duration_s=round(time.monotonic() - t0, 3))
 
     proposals = []
     for a in actors:
@@ -245,16 +262,30 @@ async def _run_flat_step(
 
     if is_review_step:
         if critics:
-            critic_tasks = [
-                _invoke_with_semaphore(
-                    agent_semaphore, c, board.workspace, step_num,
-                    build_prompt(c, step_num, rules), timeout, max_concurrent,
-                ) if agent_semaphore else _invoke_with_retry(
-                    c, board.workspace, step_num, build_prompt(c, step_num, rules), timeout,
-                )
-                for c in critics
-            ]
-            await asyncio.gather(*critic_tasks, return_exceptions=True)
+            logger.debug("flat_step.critique_start", step=step_num, n_critics=len(critics))
+            t1 = time.monotonic()
+            try:
+                async with asyncio.TaskGroup() as tg:
+                    for c in critics:
+                        coro = (
+                            _invoke_with_semaphore(
+                                agent_semaphore, c, board.workspace, step_num,
+                                build_prompt(c, step_num, rules), timeout, max_concurrent,
+                            ) if agent_semaphore else _invoke_with_retry(
+                                c, board.workspace, step_num, build_prompt(c, step_num, rules),
+                                timeout,
+                            )
+                        )
+                        tg.create_task(_safe_invoke(coro))
+            except ExceptionGroup as eg:
+                for exc in eg.exceptions:
+                    logger.error(
+                        "flat_step.critique.unhandled_failure", step=step_num, error=str(exc),
+                    )
+            logger.debug(
+                "flat_step.critique_done", step=step_num,
+                duration_s=round(time.monotonic() - t1, 3),
+            )
 
             for c in critics:
                 cr = parse_critique(board.workspace, c.name, step_num)
@@ -263,9 +294,17 @@ async def _run_flat_step(
                     board.save_critique(cr, step_num)
 
         if judges:
+            logger.debug("flat_step.resolve_start", step=step_num)
+            t2 = time.monotonic()
             judge = judges[0]
-            await _invoke_with_retry(judge, board.workspace, step_num, build_prompt(judge, step_num, rules), timeout)
+            await _invoke_with_retry(
+                judge, board.workspace, step_num, build_prompt(judge, step_num, rules), timeout,
+            )
             resolution = parse_resolution(board.workspace, step_num)
+            logger.debug(
+                "flat_step.resolve_done", step=step_num,
+                duration_s=round(time.monotonic() - t2, 3),
+            )
 
         if resolution is None:
             resolution = _fallback_resolution(proposals)
@@ -327,22 +366,44 @@ async def _run_entity_step(
     critic_entities = [e for e in scenario.entities if e.type == TrajectoryType.CRITIC]
     eval_entities = [e for e in scenario.entities if e.type == TrajectoryType.EVALUATOR]
 
+    logger.debug(
+        "entity_step.order",
+        step=step_num,
+        n_forces=len(force_entities),
+        n_populations=len(pop_entities),
+        n_critics=len(critic_entities),
+        n_evaluators=len(eval_entities),
+    )
+
     # Phase 1: Forces propose world-level changes
     force_agents = [a for e in force_entities for a in e.agents]
     if force_agents:
-        force_tasks = [
-            _invoke_with_semaphore(
-                agent_semaphore, a, board.workspace, step_num,
-                build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
-                timeout, max_concurrent,
-            ) if agent_semaphore else _invoke_with_retry(
-                a, board.workspace, step_num,
-                build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
-                timeout,
-            )
-            for a in force_agents
-        ]
-        await asyncio.gather(*force_tasks, return_exceptions=True)
+        logger.debug("entity_step.forces_start", step=step_num, n_agents=len(force_agents))
+        t0 = time.monotonic()
+        try:
+            async with asyncio.TaskGroup() as tg:
+                for a in force_agents:
+                    coro = (
+                        _invoke_with_semaphore(
+                            agent_semaphore, a, board.workspace, step_num,
+                            build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
+                            timeout, max_concurrent,
+                        ) if agent_semaphore else _invoke_with_retry(
+                            a, board.workspace, step_num,
+                            build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
+                            timeout,
+                        )
+                    )
+                    tg.create_task(_safe_invoke(coro))
+        except ExceptionGroup as eg:
+            for exc in eg.exceptions:
+                logger.error(
+                    "entity_step.forces.unhandled_failure", step=step_num, error=str(exc),
+                )
+        logger.debug(
+            "entity_step.forces_done", step=step_num,
+            duration_s=round(time.monotonic() - t0, 3),
+        )
         for a in force_agents:
             p = parse_proposal(board.workspace, a.name, step_num)
             if p:
@@ -350,7 +411,6 @@ async def _run_entity_step(
                 board.save_proposal(p, step_num)
 
     # Phase 2: Populations propose their changes (in parallel)
-    # Build interaction context per entity so agents see neighbor state
     current_state = board.read_state()
     entity_interaction: dict[str, str] = {}
     for entity in pop_entities:
@@ -360,19 +420,38 @@ async def _run_entity_step(
 
     pop_agents = [a for e in pop_entities for a in e.agents]
     if pop_agents:
-        pop_tasks = [
-            _invoke_with_semaphore(
-                agent_semaphore, a, board.workspace, step_num,
-                build_prompt(a, step_num, rules, entity_interaction.get(a.name, ""), trajectory_id=trajectory_id),
-                timeout, max_concurrent,
-            ) if agent_semaphore else _invoke_with_retry(
-                a, board.workspace, step_num,
-                build_prompt(a, step_num, rules, entity_interaction.get(a.name, ""), trajectory_id=trajectory_id),
-                timeout,
-            )
-            for a in pop_agents
-        ]
-        await asyncio.gather(*pop_tasks, return_exceptions=True)
+        logger.debug("entity_step.populations_start", step=step_num, n_agents=len(pop_agents))
+        t1 = time.monotonic()
+        try:
+            async with asyncio.TaskGroup() as tg:
+                for a in pop_agents:
+                    coro = (
+                        _invoke_with_semaphore(
+                            agent_semaphore, a, board.workspace, step_num,
+                            build_prompt(
+                                a, step_num, rules, entity_interaction.get(a.name, ""),
+                                trajectory_id=trajectory_id,
+                            ),
+                            timeout, max_concurrent,
+                        ) if agent_semaphore else _invoke_with_retry(
+                            a, board.workspace, step_num,
+                            build_prompt(
+                                a, step_num, rules, entity_interaction.get(a.name, ""),
+                                trajectory_id=trajectory_id,
+                            ),
+                            timeout,
+                        )
+                    )
+                    tg.create_task(_safe_invoke(coro))
+        except ExceptionGroup as eg:
+            for exc in eg.exceptions:
+                logger.error(
+                    "entity_step.populations.unhandled_failure", step=step_num, error=str(exc),
+                )
+        logger.debug(
+            "entity_step.populations_done", step=step_num,
+            duration_s=round(time.monotonic() - t1, 3),
+        )
         for a in pop_agents:
             p = parse_proposal(board.workspace, a.name, step_num)
             if p:
@@ -382,16 +461,30 @@ async def _run_entity_step(
     # Phase 3: Critics evaluate all proposals
     critic_agents = [a for e in critic_entities for a in e.agents]
     if critic_agents:
-        critic_tasks = [
-            _invoke_with_semaphore(
-                agent_semaphore, c, board.workspace, step_num,
-                build_prompt(c, step_num, rules), timeout, max_concurrent,
-            ) if agent_semaphore else _invoke_with_retry(
-                c, board.workspace, step_num, build_prompt(c, step_num, rules), timeout,
-            )
-            for c in critic_agents
-        ]
-        await asyncio.gather(*critic_tasks, return_exceptions=True)
+        logger.debug("entity_step.critics_start", step=step_num, n_agents=len(critic_agents))
+        t2 = time.monotonic()
+        try:
+            async with asyncio.TaskGroup() as tg:
+                for c in critic_agents:
+                    coro = (
+                        _invoke_with_semaphore(
+                            agent_semaphore, c, board.workspace, step_num,
+                            build_prompt(c, step_num, rules), timeout, max_concurrent,
+                        ) if agent_semaphore else _invoke_with_retry(
+                            c, board.workspace, step_num,
+                            build_prompt(c, step_num, rules), timeout,
+                        )
+                    )
+                    tg.create_task(_safe_invoke(coro))
+        except ExceptionGroup as eg:
+            for exc in eg.exceptions:
+                logger.error(
+                    "entity_step.critics.unhandled_failure", step=step_num, error=str(exc),
+                )
+        logger.debug(
+            "entity_step.critics_done", step=step_num,
+            duration_s=round(time.monotonic() - t2, 3),
+        )
         for c in critic_agents:
             cr = parse_critique(board.workspace, c.name, step_num)
             if cr:
@@ -402,9 +495,17 @@ async def _run_entity_step(
     resolution = None
     eval_agents = [a for e in eval_entities for a in e.agents if a.role == AgentRole.JUDGE]
     if eval_agents:
+        logger.debug("entity_step.resolve_start", step=step_num)
+        t3 = time.monotonic()
         judge = eval_agents[0]
-        await _invoke_with_retry(judge, board.workspace, step_num, build_prompt(judge, step_num, rules), timeout)
+        await _invoke_with_retry(
+            judge, board.workspace, step_num, build_prompt(judge, step_num, rules), timeout,
+        )
         resolution = parse_resolution(board.workspace, step_num)
+        logger.debug(
+            "entity_step.resolve_done", step=step_num,
+            duration_s=round(time.monotonic() - t3, 3),
+        )
 
     if resolution is None:
         resolution = _fallback_resolution(proposals)
@@ -443,18 +544,30 @@ def _check_termination(state: dict, conditions: list[dict]) -> bool:
         field = cond.get("field", "")
         value = _get_nested(state, field)
         if value is None:
+            logger.debug("termination.condition_skip", field=field, reason="field_not_found")
             continue
         if "equals" in cond and value == cond["equals"]:
+            logger.debug("termination.condition_met", field=field, op="equals", value=value)
             return True
         if "greater_than" in cond and isinstance(value, (int, float)) and value > cond["greater_than"]:
+            logger.debug(
+                "termination.condition_met", field=field, op="greater_than",
+                value=value, threshold=cond["greater_than"],
+            )
             return True
         if "less_than" in cond and isinstance(value, (int, float)) and value < cond["less_than"]:
+            logger.debug(
+                "termination.condition_met", field=field, op="less_than",
+                value=value, threshold=cond["less_than"],
+            )
             return True
+        logger.debug("termination.condition_not_met", field=field, value=value)
     return False
 
 
 def _classify_outcome(state: dict, scenario: Scenario) -> str:
     if scenario.outcome is None:
+        logger.debug("classify.skip", reason="no_outcome_config")
         return "unclassified"
 
     for oc in scenario.outcome.classifier:
@@ -466,16 +579,21 @@ def _classify_outcome(state: dict, scenario: Scenario) -> str:
         if value is None:
             continue
         if oc.condition.equals is not None and value == oc.condition.equals:
+            logger.info("classify.result", classification=oc.name)
             return oc.name
         if oc.condition.greater_than is not None and isinstance(value, (int, float)) and value > oc.condition.greater_than:
+            logger.info("classify.result", classification=oc.name)
             return oc.name
         if oc.condition.less_than is not None and isinstance(value, (int, float)) and value < oc.condition.less_than:
+            logger.info("classify.result", classification=oc.name)
             return oc.name
 
     for oc in scenario.outcome.classifier:
         if oc.default:
+            logger.info("classify.result", classification=oc.name, default=True)
             return oc.name
 
+    logger.info("classify.result", classification="unclassified", default=True)
     return "unclassified"
 
 

--- a/src/minimal_agora/runner.py
+++ b/src/minimal_agora/runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from copy import deepcopy
 from pathlib import Path
 
@@ -37,27 +38,49 @@ async def run_batch(
 
     semaphore = asyncio.Semaphore(concurrency)
     results: list[Trajectory] = []
+    completed: list[Trajectory | BaseException | None] = [None] * n
 
-    async def run_one(tid: int) -> Trajectory:
-        async with semaphore:
-            workspace = setup_workspace(scenario, output_dir, tid)
-            print(f"[batch] starting trajectory {tid}/{n}")
-            return await run_trajectory(scenario, workspace, tid, agent_timeout)
+    logger.info("batch.start", n_trajectories=n, concurrency=concurrency)
+    t0 = time.monotonic()
 
-    tasks = [run_one(i) for i in range(n)]
-    completed = await asyncio.gather(*tasks, return_exceptions=True)
+    async def _safe_run_one(tid: int) -> None:
+        try:
+            async with semaphore:
+                workspace = setup_workspace(scenario, output_dir, tid)
+                print(f"[batch] starting trajectory {tid}/{n}")
+                completed[tid] = await run_trajectory(scenario, workspace, tid, agent_timeout)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("trajectory.failed", trajectory_id=tid, error=str(e))
+            completed[tid] = e
 
+    try:
+        async with asyncio.TaskGroup() as tg:
+            for i in range(n):
+                tg.create_task(_safe_run_one(i))
+    except ExceptionGroup as eg:
+        for exc in eg.exceptions:
+            logger.error("batch.unhandled_failure", error=str(exc))
+
+    n_failed = 0
     skipped = 0
     for i, result in enumerate(completed):
         if isinstance(result, BaseException):
             print(f"[batch] trajectory {i} failed: {result}")
-        else:
+            n_failed += 1
+        elif result is not None:
             results.append(result)
             if result.outcome and result.metadata.get("resumed"):
                 skipped += 1
 
     if skipped:
         print(f"[batch] {skipped}/{n} trajectories resumed from checkpoint")
+
+    logger.info(
+        "batch.complete",
+        n_completed=len(results),
+        n_failed=n_failed,
+        duration_s=round(time.monotonic() - t0, 3),
+    )
 
     return results
 
@@ -73,6 +96,9 @@ async def run_particle_filter(
     resample_cfg = scenario.resampling
     if resample_cfg is None:
         return await run_batch(scenario, output_dir, concurrency, agent_timeout)
+
+    logger.info("filter.start", n_trajectories=n, concurrency=concurrency)
+    t0 = time.monotonic()
 
     max_steps = scenario.termination.get("max_steps", scenario.step_budget)
     semaphore = asyncio.Semaphore(concurrency)
@@ -97,17 +123,28 @@ async def run_particle_filter(
 
         is_last = step_num == max_steps - 1
 
-        async def run_one_step(idx: int, _boards=boards, _step_num=step_num) -> None:
-            async with semaphore:
-                state_before = deepcopy(_boards[idx].read_state())
-                step = await _run_flat_step(
-                    scenario, _boards[idx], _step_num, agent_timeout,
-                    state_before, trajectory_id=idx,
-                    agent_semaphore=agent_sem, max_steps=max_steps,
+        async def _safe_run_step(idx: int, _boards=boards, _step_num=step_num) -> None:
+            try:
+                async with semaphore:
+                    state_before = deepcopy(_boards[idx].read_state())
+                    step = await _run_flat_step(
+                        scenario, _boards[idx], _step_num, agent_timeout,
+                        state_before, trajectory_id=idx,
+                        agent_semaphore=agent_sem, max_steps=max_steps,
+                    )
+                    all_steps[idx].append(step)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "particle.step_failed", trajectory_id=idx, step=_step_num, error=str(e),
                 )
-                all_steps[idx].append(step)
 
-        await asyncio.gather(*[run_one_step(i) for i in range(n)], return_exceptions=True)
+        try:
+            async with asyncio.TaskGroup() as tg:
+                for i in range(n):
+                    tg.create_task(_safe_run_step(i))
+        except ExceptionGroup as eg:
+            for exc in eg.exceptions:
+                logger.error("filter.step.unhandled_failure", step=step_num, error=str(exc))
 
         if (
             step_num > 0
@@ -115,6 +152,7 @@ async def run_particle_filter(
             and not is_last
             and n > resample_cfg.min_particles
         ):
+            logger.info("filter.resample", step=step_num)
             workspaces = await resample_particles(
                 scenario, workspaces, step_num, agent_timeout, agent_sem,
             )
@@ -136,5 +174,11 @@ async def run_particle_filter(
             ),
         )
         trajectories.append(traj)
+
+    logger.info(
+        "filter.complete",
+        n_trajectories=len(trajectories),
+        duration_s=round(time.monotonic() - t0, 3),
+    )
 
     return trajectories


### PR DESCRIPTION
Closes #14, Closes #15

## Changes

- **Gitignore**: added `.coverage`, `.factory/`, `.factory-worktrees/`, `*.egg-info/`, `dist/`, `build/`, `.mypy_cache/`, `.ruff_cache/`, `htmlcov/`, `.venv/`, `*.env`, `skills/`
- **Observability logging (Issue #14)**: added structlog `debug`/`info` calls to all previously uninstrumented functions across `agents.py`, `loop.py`, `runner.py`, and `analysis.py` — prompt builders, parse success paths, phase transitions with monotonic timing, termination condition checks, classification results, batch/filter lifecycle events, and statistical analysis functions
- **TaskGroup migration (Issue #15)**: replaced all `asyncio.gather(*tasks, return_exceptions=True)` calls in `loop.py` and `runner.py` with `asyncio.TaskGroup`, wrapping each task in `_safe_invoke` to preserve continue-on-failure semantics. `ExceptionGroup` caught as a safety net around all TaskGroup blocks.

All 131 tests pass. Ruff and mypy clean.