### PR TITLE
Optimize agent prompts: embed state directly, eliminate tool-use round-trips

### DIFF
--- a/src/minimal_agora/agents.py
+++ b/src/minimal_agora/agents.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
 
 import structlog
@@ -157,140 +159,257 @@ def _diversity_prefix(trajectory_id: int) -> str:
     return f"**Exploration lens (trajectory {trajectory_id})**: {lens}"
 
 
-def build_actor_prompt(agent: AgentConfig, step: int, rules: list[SimRule] | None = None, interaction_context: str = "", trajectory_id: int | None = None) -> str:
+def _format_wildcard(wildcard: dict | None) -> str:
+    if not wildcard:
+        return ""
+    impact = wildcard.get("state_impact", {})
+    impact_str = f"\nImpact: {json.dumps(impact, indent=2)}" if impact else ""
+    return (
+        f"\n## Active Wildcard Event\n"
+        f"**{wildcard['name']}**: {wildcard.get('description', '')}{impact_str}\n"
+        f"This is a major external shock that MUST be accounted for in your proposal.\n"
+    )
+
+
+def build_actor_prompt(
+    agent: AgentConfig,
+    step: int,
+    rules: list[SimRule] | None = None,
+    interaction_context: str = "",
+    trajectory_id: int | None = None,
+    state: dict | None = None,
+    narrative: str | None = None,
+    wildcard: dict | None = None,
+) -> str:
     logger.debug(
         "prompt.build_actor",
         agent=agent.name,
         step=step,
-        has_wildcard=True,
+        has_wildcard=wildcard is not None,
         has_interaction_context=bool(interaction_context),
+        embedded_state=state is not None,
     )
     rules_block = _format_rules(rules or [], agent.name, agent.role.value)
     interaction_block = f"\n{interaction_context}\n" if interaction_context else ""
     diversity_block = f"\n{_diversity_prefix(trajectory_id)}\n" if trajectory_id is not None else ""
-    return f"""You are **{agent.name}**, an actor agent in a world simulation.
-{diversity_block}
-## Your Perspective
-{agent.perspective}
+    wildcard_block = _format_wildcard(wildcard)
 
-{rules_block}{interaction_block}## Instructions
-1. Read the current world state from `board/state.json`
-2. Read the narrative history from `board/narrative.md`
-3. Read the scenario description from `board/scenario.md`
+    if state is not None:
+        state_section = (
+            f"## Simulation Step {step}\n\n"
+            f"## Current World State\n```json\n{json.dumps(state, indent=2)}\n```\n"
+        )
+        narrative_section = f"\n## Narrative History\n{narrative or '(No narrative yet.)'}\n"
+        instructions = (
+            f"{wildcard_block}"
+            f"\n## Instructions\n"
+            f"Based on the current state, any active wildcard, and your perspective, propose\n"
+            f"what happens next in this time step. Think carefully about what changes are\n"
+            f"most likely given your domain of influence.\n\n"
+            f"Respond with ONLY a JSON object (no markdown fences, no explanation):\n"
+            f'{{"agent": "{agent.name}", "role": "actor", '
+            f'"proposed_changes": {{"path.to.field": "new_value"}}, '
+            f'"reasoning": "Why these changes happen", "confidence": 0.7}}\n\n'
+            f"The `proposed_changes` should be a flat or nested dict matching the structure\n"
+            f"of the world state. Only include fields you want to change.\n"
+        )
+    else:
+        state_section = ""
+        narrative_section = ""
+        instructions = (
+            f"## Instructions\n"
+            f"1. Read the current world state from `board/state.json`\n"
+            f"2. Read the narrative history from `board/narrative.md`\n"
+            f"3. Read the scenario description from `board/scenario.md`\n\n"
+            f"Check if a wildcard event file exists at `board/wildcard_step_{step:03d}.json`.\n"
+            f"If present, this is a major external shock (asteroid, pandemic, war, etc.)\n"
+            f"that MUST be accounted for in your proposal. The wildcard's `state_impact`\n"
+            f"suggests direct effects, but you should also reason about cascading consequences.\n\n"
+            f"Based on the current state, any active wildcard, and your perspective, propose\n"
+            f"what happens next in this time step. Think carefully about what changes are\n"
+            f"most likely given your domain of influence.\n\n"
+            f"4. Write your proposal as a JSON file to `proposals/step_{step:03d}_{agent.name}.json`\n\n"
+            f"The JSON must have this structure:\n"
+            f"```json\n"
+            f"{{\n"
+            f'  "agent": "{agent.name}",\n'
+            f'  "role": "actor",\n'
+            f'  "proposed_changes": {{\n'
+            f'    "path.to.field": "new_value"\n'
+            f"  }},\n"
+            f'  "reasoning": "Why these changes happen",\n'
+            f'  "confidence": 0.7\n'
+            f"}}\n"
+            f"```\n\n"
+            f"The `proposed_changes` should be a flat or nested dict matching the structure\n"
+            f"of state.json. Only include fields you want to change.\n"
+        )
 
-Check if a wildcard event file exists at `board/wildcard_step_{step:03d}.json`.
-If present, this is a major external shock (asteroid, pandemic, war, etc.)
-that MUST be accounted for in your proposal. The wildcard's `state_impact`
-suggests direct effects, but you should also reason about cascading consequences.
-
-Based on the current state, any active wildcard, and your perspective, propose
-what happens next in this time step. Think carefully about what changes are
-most likely given your domain of influence.
-
-4. Write your proposal as a JSON file to `proposals/step_{step:03d}_{agent.name}.json`
-
-The JSON must have this structure:
-```json
-{{
-  "agent": "{agent.name}",
-  "role": "actor",
-  "proposed_changes": {{
-    "path.to.field": "new_value"
-  }},
-  "reasoning": "Why these changes happen",
-  "confidence": 0.7
-}}
-```
-
-The `proposed_changes` should be a flat or nested dict matching the structure
-of state.json. Only include fields you want to change.
-"""
+    return (
+        f"You are **{agent.name}**, an actor agent in a world simulation.\n"
+        f"{diversity_block}\n"
+        f"## Your Perspective\n"
+        f"{agent.perspective}\n\n"
+        f"{state_section}"
+        f"{narrative_section}"
+        f"{rules_block}{interaction_block}"
+        f"{instructions}"
+    )
 
 
-def build_critic_prompt(agent: AgentConfig, step: int, rules: list[SimRule] | None = None) -> str:
-    logger.debug("prompt.build_critic", agent=agent.name, step=step)
+def build_critic_prompt(
+    agent: AgentConfig,
+    step: int,
+    rules: list[SimRule] | None = None,
+    state: dict | None = None,
+    narrative: str | None = None,
+    proposals: list[dict] | None = None,
+    wildcard: dict | None = None,
+) -> str:
+    logger.debug(
+        "prompt.build_critic",
+        agent=agent.name,
+        step=step,
+        embedded_state=state is not None,
+    )
     rules_block = _format_rules(rules or [], agent.name, agent.role.value)
-    return f"""You are **{agent.name}**, a critic agent in a world simulation.
+    wildcard_block = _format_wildcard(wildcard)
 
-## Your Perspective
-{agent.perspective}
+    if state is not None:
+        proposals_json = json.dumps(proposals or [], indent=2)
+        return (
+            f"You are **{agent.name}**, a critic agent in a world simulation.\n\n"
+            f"## Your Perspective\n{agent.perspective}\n\n"
+            f"## Current World State\n```json\n{json.dumps(state, indent=2)}\n```\n\n"
+            f"## Narrative History\n{narrative or '(No narrative yet.)'}\n\n"
+            f"## Proposals for Step {step}\n```json\n{proposals_json}\n```\n\n"
+            f"{rules_block}"
+            f"{wildcard_block}"
+            f"\n## Instructions\n"
+            f"Evaluate each proposal for plausibility, consistency, and realism.\n"
+            f"Flag anything impossible, contradictory, or highly unlikely.\n\n"
+            f"Respond with ONLY a JSON object (no markdown fences, no explanation):\n"
+            f'{{"agent": "{agent.name}", "target_proposals": ["agent1", "agent2"], '
+            f'"assessment": "Overall assessment", "plausibility": 0.8, '
+            f'"issues": ["Issue 1", "Issue 2"]}}\n'
+        )
 
-{rules_block}
-## Instructions
-1. Read the current world state from `board/state.json`
-2. Read the narrative history from `board/narrative.md`
-3. Read ALL proposals in `proposals/` for step {step:03d}
+    return (
+        f"You are **{agent.name}**, a critic agent in a world simulation.\n\n"
+        f"## Your Perspective\n{agent.perspective}\n\n"
+        f"{rules_block}\n"
+        f"## Instructions\n"
+        f"1. Read the current world state from `board/state.json`\n"
+        f"2. Read the narrative history from `board/narrative.md`\n"
+        f"3. Read ALL proposals in `proposals/` for step {step:03d}\n\n"
+        f"Check if a wildcard event file exists at `board/wildcard_step_{step:03d}.json`.\n"
+        f"If present, evaluate whether proposals adequately account for its impact.\n\n"
+        f"Evaluate each proposal for plausibility, consistency, and realism.\n"
+        f"Flag anything impossible, contradictory, or highly unlikely.\n\n"
+        f"4. Write your critique as a JSON file to `critiques/step_{step:03d}_{agent.name}.json`\n\n"
+        f"The JSON must have this structure:\n"
+        f"```json\n"
+        f"{{\n"
+        f'  "agent": "{agent.name}",\n'
+        f'  "target_proposals": ["proposal_agent_1", "proposal_agent_2"],\n'
+        f'  "assessment": "Overall assessment of the proposals",\n'
+        f'  "plausibility": 0.8,\n'
+        f'  "issues": ["Issue 1", "Issue 2"]\n'
+        f"}}\n"
+        f"```\n"
+    )
 
-Check if a wildcard event file exists at `board/wildcard_step_{step:03d}.json`.
-If present, evaluate whether proposals adequately account for its impact.
 
-Evaluate each proposal for plausibility, consistency, and realism.
-Flag anything impossible, contradictory, or highly unlikely.
-
-4. Write your critique as a JSON file to `critiques/step_{step:03d}_{agent.name}.json`
-
-The JSON must have this structure:
-```json
-{{
-  "agent": "{agent.name}",
-  "target_proposals": ["proposal_agent_1", "proposal_agent_2"],
-  "assessment": "Overall assessment of the proposals",
-  "plausibility": 0.8,
-  "issues": ["Issue 1", "Issue 2"]
-}}
-```
-"""
-
-
-def build_judge_prompt(agent: AgentConfig, step: int, rules: list[SimRule] | None = None) -> str:
-    logger.debug("prompt.build_judge", agent=agent.name, step=step)
+def build_judge_prompt(
+    agent: AgentConfig,
+    step: int,
+    rules: list[SimRule] | None = None,
+    state: dict | None = None,
+    narrative: str | None = None,
+    proposals: list[dict] | None = None,
+    critiques: list[dict] | None = None,
+    wildcard: dict | None = None,
+) -> str:
+    logger.debug(
+        "prompt.build_judge",
+        agent=agent.name,
+        step=step,
+        embedded_state=state is not None,
+    )
     rules_block = _format_rules(rules or [], agent.name, agent.role.value)
-    return f"""You are **{agent.name}**, the judge agent in a world simulation.
+    wildcard_block = _format_wildcard(wildcard)
 
-## Your Perspective
-{agent.perspective}
+    if state is not None:
+        proposals_json = json.dumps(proposals or [], indent=2)
+        critiques_json = json.dumps(critiques or [], indent=2)
+        return (
+            f"You are **{agent.name}**, the judge agent in a world simulation.\n\n"
+            f"## Your Perspective\n{agent.perspective}\n\n"
+            f"## Current World State\n```json\n{json.dumps(state, indent=2)}\n```\n\n"
+            f"## Narrative History\n{narrative or '(No narrative yet.)'}\n\n"
+            f"## Proposals for Step {step}\n```json\n{proposals_json}\n```\n\n"
+            f"## Critiques for Step {step}\n```json\n{critiques_json}\n```\n\n"
+            f"{rules_block}"
+            f"{wildcard_block}"
+            f"\n## Instructions\n"
+            f"Synthesize the proposals and critiques into a single coherent outcome for this\n"
+            f"time step. Resolve conflicts between proposals. Weight proposals by their\n"
+            f"plausibility as assessed by critics.\n\n"
+            f"The `state_delta` will be deep-merged into the current state. Only include\n"
+            f"fields that change. The narrative should be written as a historical account,\n"
+            f"not a technical description.\n\n"
+            f"Respond with ONLY a JSON object (no markdown fences, no explanation):\n"
+            f'{{"state_delta": {{"path.to.field": "new_value"}}, '
+            f'"narrative": "A paragraph describing what happened", '
+            f'"reasoning": "Why you resolved conflicts this way"}}\n'
+        )
 
-{rules_block}
-## Instructions
-1. Read the current world state from `board/state.json`
-2. Read the narrative history from `board/narrative.md`
-3. Read ALL proposals in `proposals/` for step {step:03d}
-4. Read ALL critiques in `critiques/` for step {step:03d}
-
-Check if a wildcard event file exists at `board/wildcard_step_{step:03d}.json`.
-If present, ensure the resolution fully accounts for the wildcard's impact,
-including applying its `state_impact` and any cascading effects.
-
-Synthesize the proposals and critiques into a single coherent outcome for this
-time step. Resolve conflicts between proposals. Weight proposals by their
-plausibility as assessed by critics.
-
-5. Write your resolution as a JSON file to `resolutions/step_{step:03d}_resolution.json`
-
-The JSON must have this structure:
-```json
-{{
-  "state_delta": {{
-    "path.to.field": "new_value"
-  }},
-  "narrative": "A paragraph describing what happened this step and why",
-  "reasoning": "Why you resolved conflicts this way"
-}}
-```
-
-The `state_delta` will be deep-merged into the current state. Only include
-fields that change. The narrative should be written as a historical account,
-not a technical description.
-"""
+    return (
+        f"You are **{agent.name}**, the judge agent in a world simulation.\n\n"
+        f"## Your Perspective\n{agent.perspective}\n\n"
+        f"{rules_block}\n"
+        f"## Instructions\n"
+        f"1. Read the current world state from `board/state.json`\n"
+        f"2. Read the narrative history from `board/narrative.md`\n"
+        f"3. Read ALL proposals in `proposals/` for step {step:03d}\n"
+        f"4. Read ALL critiques in `critiques/` for step {step:03d}\n\n"
+        f"Check if a wildcard event file exists at `board/wildcard_step_{step:03d}.json`.\n"
+        f"If present, ensure the resolution fully accounts for the wildcard's impact,\n"
+        f"including applying its `state_impact` and any cascading effects.\n\n"
+        f"Synthesize the proposals and critiques into a single coherent outcome for this\n"
+        f"time step. Resolve conflicts between proposals. Weight proposals by their\n"
+        f"plausibility as assessed by critics.\n\n"
+        f"5. Write your resolution as a JSON file to `resolutions/step_{step:03d}_resolution.json`\n\n"
+        f"The JSON must have this structure:\n"
+        f"```json\n"
+        f"{{\n"
+        f'  "state_delta": {{\n'
+        f'    "path.to.field": "new_value"\n'
+        f"  }},\n"
+        f'  "narrative": "A paragraph describing what happened this step and why",\n'
+        f'  "reasoning": "Why you resolved conflicts this way"\n'
+        f"}}\n"
+        f"```\n\n"
+        f"The `state_delta` will be deep-merged into the current state. Only include\n"
+        f"fields that change. The narrative should be written as a historical account,\n"
+        f"not a technical description.\n"
+    )
 
 
-def build_prompt(agent: AgentConfig, step: int, rules: list[SimRule] | None = None, interaction_context: str = "", trajectory_id: int | None = None) -> str:
+def build_prompt(
+    agent: AgentConfig,
+    step: int,
+    rules: list[SimRule] | None = None,
+    interaction_context: str = "",
+    trajectory_id: int | None = None,
+    **kwargs: object,
+) -> str:
     if agent.role == AgentRole.ACTOR:
-        return build_actor_prompt(agent, step, rules, interaction_context, trajectory_id)
+        return build_actor_prompt(agent, step, rules, interaction_context, trajectory_id, **kwargs)
     elif agent.role == AgentRole.CRITIC:
-        return build_critic_prompt(agent, step, rules)
+        return build_critic_prompt(agent, step, rules, **kwargs)
     elif agent.role == AgentRole.JUDGE:
-        return build_judge_prompt(agent, step, rules)
+        return build_judge_prompt(agent, step, rules, **kwargs)
     raise ValueError(f"Unknown role: {agent.role}")
 
 
@@ -336,6 +455,61 @@ def parse_resolution(workspace: Path, step: int) -> Resolution | None:
         return result
     except (ValueError, OSError, KeyError) as e:
         logger.warning("Failed to parse resolution %s: %s", path.name, e)
+        return None
+
+
+def _extract_json_from_text(text: str) -> str | None:
+    """Try to extract JSON from text, handling markdown code blocks."""
+    text = text.strip()
+    try:
+        json.loads(text)
+        return text
+    except (json.JSONDecodeError, ValueError):
+        pass
+    match = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", text, re.DOTALL)
+    if match:
+        candidate = match.group(1).strip()
+        try:
+            json.loads(candidate)
+            return candidate
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return None
+
+
+def parse_proposal_from_text(text: str, agent_name: str) -> Proposal | None:
+    extracted = _extract_json_from_text(text)
+    if extracted is None:
+        logger.warning("parse.proposal_from_text.no_json", agent_name=agent_name)
+        return None
+    try:
+        return Proposal.model_validate_json(extracted)
+    except (ValueError, KeyError) as e:
+        logger.warning("parse.proposal_from_text.invalid", agent_name=agent_name, error=str(e))
+        return None
+
+
+def parse_critique_from_text(text: str, agent_name: str) -> Critique | None:
+    extracted = _extract_json_from_text(text)
+    if extracted is None:
+        logger.warning("parse.critique_from_text.no_json", agent_name=agent_name)
+        return None
+    try:
+        return Critique.model_validate_json(extracted)
+    except (ValueError, KeyError) as e:
+        logger.warning("parse.critique_from_text.invalid", agent_name=agent_name, error=str(e))
+        return None
+
+
+def parse_resolution_from_text(text: str) -> Resolution | None:
+    extracted = _extract_json_from_text(text)
+    if extracted is None:
+        logger.warning("parse.resolution_from_text.no_json")
+        return None
+    try:
+        return Resolution.model_validate_json(extracted)
+    except (ValueError, KeyError) as e:
+        logger.warning("parse.resolution_from_text.invalid", error=str(e))
         return None
 
 

--- a/src/minimal_agora/loop.py
+++ b/src/minimal_agora/loop.py
@@ -16,8 +16,11 @@ from minimal_agora.agents import (
     build_prompt,
     invoke_agent,
     parse_critique,
+    parse_critique_from_text,
     parse_proposal,
+    parse_proposal_from_text,
     parse_resolution,
+    parse_resolution_from_text,
 )
 from minimal_agora.board import Board, _atomic_write, _deep_merge, _expand_dotted_keys
 from minimal_agora.models import (
@@ -205,6 +208,59 @@ async def _run_step(
     return await _run_flat_step(scenario, board, step_num, timeout, state_before, trajectory_id, agent_semaphore, max_steps)
 
 
+def _read_narrative(board: Board) -> str:
+    try:
+        return board.narrative_path.read_text()
+    except FileNotFoundError:
+        return ""
+
+
+def _read_wildcard_dict(board: Board, step_num: int) -> dict | None:
+    import json as _json
+    path = board.workspace / "board" / f"wildcard_step_{step_num:03d}.json"
+    if not path.exists():
+        return None
+    with open(path) as f:
+        return _json.load(f)
+
+
+async def _invoke_and_collect(
+    agent,
+    workspace: Path,
+    step_num: int,
+    prompt: str,
+    timeout: int,
+    agent_semaphore: asyncio.Semaphore | None,
+    max_concurrent: int,
+) -> str | None:
+    try:
+        if agent_semaphore:
+            if agent_semaphore.locked():
+                logger.debug("agent.throttled", agent=agent.name, waiting=True)
+            async with agent_semaphore:
+                logger.debug("agent.semaphore_acquired", agent=agent.name, max_concurrent=max_concurrent)
+                return await _invoke_with_retry_return(agent, workspace, step_num, prompt, timeout)
+        else:
+            return await _invoke_with_retry_return(agent, workspace, step_num, prompt, timeout)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("agent.task_failed", agent=agent.name, error=str(e))
+        return None
+
+
+async def _invoke_with_retry_return(
+    agent, workspace: Path, step_num: int, prompt: str, timeout: int, max_retries: int = 1,
+) -> str | None:
+    for attempt in range(1 + max_retries):
+        try:
+            return await invoke_agent(agent, workspace, step_num, prompt, timeout)
+        except (OSError, RuntimeError, TimeoutError) as e:
+            if attempt < max_retries:
+                logger.warning("Agent %s failed (attempt %d), retrying: %s", agent.name, attempt + 1, e)
+            else:
+                logger.error("Agent %s failed after %d attempts: %s", agent.name, attempt + 1, e)
+    return None
+
+
 async def _run_flat_step(
     scenario: Scenario,
     board: Board,
@@ -222,23 +278,32 @@ async def _run_flat_step(
     max_concurrent = scenario.max_concurrent_agents
     rules = scenario.rules
 
+    current_state = board.read_state()
+    narrative_text = _read_narrative(board)
+    wildcard_dict = _read_wildcard_dict(board, step_num)
+
+    embed_kwargs: dict = {
+        "state": current_state,
+        "narrative": narrative_text,
+        "wildcard": wildcard_dict,
+    }
+
     logger.debug("flat_step.propose_start", step=step_num, n_actors=len(actors))
     t0 = time.monotonic()
+
+    actor_outputs: dict[str, str | None] = {}
+
+    async def _run_actor(a):
+        prompt = build_prompt(a, step_num, rules, trajectory_id=trajectory_id, **embed_kwargs)
+        result = await _invoke_and_collect(
+            a, board.workspace, step_num, prompt, timeout, agent_semaphore, max_concurrent,
+        )
+        actor_outputs[a.name] = result
+
     try:
         async with asyncio.TaskGroup() as tg:
             for a in actors:
-                coro = (
-                    _invoke_with_semaphore(
-                        agent_semaphore, a, board.workspace, step_num,
-                        build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
-                        timeout, max_concurrent,
-                    ) if agent_semaphore else _invoke_with_retry(
-                        a, board.workspace, step_num,
-                        build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
-                        timeout,
-                    )
-                )
-                tg.create_task(_safe_invoke(coro))
+                tg.create_task(_run_actor(a))
     except ExceptionGroup as eg:
         for exc in eg.exceptions:
             logger.error("flat_step.propose.unhandled_failure", step=step_num, error=str(exc))
@@ -246,7 +311,12 @@ async def _run_flat_step(
 
     proposals = []
     for a in actors:
-        p = parse_proposal(board.workspace, a.name, step_num)
+        output = actor_outputs.get(a.name)
+        p = None
+        if output:
+            p = parse_proposal_from_text(output, a.name)
+        if p is None:
+            p = parse_proposal(board.workspace, a.name, step_num)
         if p:
             proposals.append(p)
             board.save_proposal(p, step_num)
@@ -262,21 +332,25 @@ async def _run_flat_step(
 
     if is_review_step:
         if critics:
+            proposals_dicts = [p.model_dump() for p in proposals]
+            critic_kwargs = {**embed_kwargs, "proposals": proposals_dicts}
+
             logger.debug("flat_step.critique_start", step=step_num, n_critics=len(critics))
             t1 = time.monotonic()
+
+            critic_outputs: dict[str, str | None] = {}
+
+            async def _run_critic(c):
+                prompt = build_prompt(c, step_num, rules, **critic_kwargs)
+                result = await _invoke_and_collect(
+                    c, board.workspace, step_num, prompt, timeout, agent_semaphore, max_concurrent,
+                )
+                critic_outputs[c.name] = result
+
             try:
                 async with asyncio.TaskGroup() as tg:
                     for c in critics:
-                        coro = (
-                            _invoke_with_semaphore(
-                                agent_semaphore, c, board.workspace, step_num,
-                                build_prompt(c, step_num, rules), timeout, max_concurrent,
-                            ) if agent_semaphore else _invoke_with_retry(
-                                c, board.workspace, step_num, build_prompt(c, step_num, rules),
-                                timeout,
-                            )
-                        )
-                        tg.create_task(_safe_invoke(coro))
+                        tg.create_task(_run_critic(c))
             except ExceptionGroup as eg:
                 for exc in eg.exceptions:
                     logger.error(
@@ -288,7 +362,12 @@ async def _run_flat_step(
             )
 
             for c in critics:
-                cr = parse_critique(board.workspace, c.name, step_num)
+                output = critic_outputs.get(c.name)
+                cr = None
+                if output:
+                    cr = parse_critique_from_text(output, c.name)
+                if cr is None:
+                    cr = parse_critique(board.workspace, c.name, step_num)
                 if cr:
                     critiques.append(cr)
                     board.save_critique(cr, step_num)
@@ -297,10 +376,19 @@ async def _run_flat_step(
             logger.debug("flat_step.resolve_start", step=step_num)
             t2 = time.monotonic()
             judge = judges[0]
-            await _invoke_with_retry(
-                judge, board.workspace, step_num, build_prompt(judge, step_num, rules), timeout,
+            judge_kwargs = {
+                **embed_kwargs,
+                "proposals": [p.model_dump() for p in proposals],
+                "critiques": [c.model_dump() for c in critiques],
+            }
+            prompt = build_prompt(judge, step_num, rules, **judge_kwargs)
+            judge_output = await _invoke_with_retry_return(
+                judge, board.workspace, step_num, prompt, timeout,
             )
-            resolution = parse_resolution(board.workspace, step_num)
+            if judge_output:
+                resolution = parse_resolution_from_text(judge_output)
+            if resolution is None:
+                resolution = parse_resolution(board.workspace, step_num)
             logger.debug(
                 "flat_step.resolve_done", step=step_num,
                 duration_s=round(time.monotonic() - t2, 3),
@@ -375,26 +463,33 @@ async def _run_entity_step(
         n_evaluators=len(eval_entities),
     )
 
+    current_state = board.read_state()
+    narrative_text = _read_narrative(board)
+    wildcard_dict = _read_wildcard_dict(board, step_num)
+    embed_kwargs: dict = {
+        "state": current_state,
+        "narrative": narrative_text,
+        "wildcard": wildcard_dict,
+    }
+
     # Phase 1: Forces propose world-level changes
     force_agents = [a for e in force_entities for a in e.agents]
     if force_agents:
         logger.debug("entity_step.forces_start", step=step_num, n_agents=len(force_agents))
         t0 = time.monotonic()
+        force_outputs: dict[str, str | None] = {}
+
+        async def _run_force(a):
+            prompt = build_prompt(a, step_num, rules, trajectory_id=trajectory_id, **embed_kwargs)
+            result = await _invoke_and_collect(
+                a, board.workspace, step_num, prompt, timeout, agent_semaphore, max_concurrent,
+            )
+            force_outputs[a.name] = result
+
         try:
             async with asyncio.TaskGroup() as tg:
                 for a in force_agents:
-                    coro = (
-                        _invoke_with_semaphore(
-                            agent_semaphore, a, board.workspace, step_num,
-                            build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
-                            timeout, max_concurrent,
-                        ) if agent_semaphore else _invoke_with_retry(
-                            a, board.workspace, step_num,
-                            build_prompt(a, step_num, rules, trajectory_id=trajectory_id),
-                            timeout,
-                        )
-                    )
-                    tg.create_task(_safe_invoke(coro))
+                    tg.create_task(_run_force(a))
         except ExceptionGroup as eg:
             for exc in eg.exceptions:
                 logger.error(
@@ -405,7 +500,12 @@ async def _run_entity_step(
             duration_s=round(time.monotonic() - t0, 3),
         )
         for a in force_agents:
-            p = parse_proposal(board.workspace, a.name, step_num)
+            output = force_outputs.get(a.name)
+            p = None
+            if output:
+                p = parse_proposal_from_text(output, a.name)
+            if p is None:
+                p = parse_proposal(board.workspace, a.name, step_num)
             if p:
                 proposals.append(p)
                 board.save_proposal(p, step_num)
@@ -418,31 +518,28 @@ async def _run_entity_step(
         for a in entity.agents:
             entity_interaction[a.name] = ctx
 
+    embed_kwargs["state"] = current_state
+
     pop_agents = [a for e in pop_entities for a in e.agents]
     if pop_agents:
         logger.debug("entity_step.populations_start", step=step_num, n_agents=len(pop_agents))
         t1 = time.monotonic()
+        pop_outputs: dict[str, str | None] = {}
+
+        async def _run_pop(a):
+            prompt = build_prompt(
+                a, step_num, rules, entity_interaction.get(a.name, ""),
+                trajectory_id=trajectory_id, **embed_kwargs,
+            )
+            result = await _invoke_and_collect(
+                a, board.workspace, step_num, prompt, timeout, agent_semaphore, max_concurrent,
+            )
+            pop_outputs[a.name] = result
+
         try:
             async with asyncio.TaskGroup() as tg:
                 for a in pop_agents:
-                    coro = (
-                        _invoke_with_semaphore(
-                            agent_semaphore, a, board.workspace, step_num,
-                            build_prompt(
-                                a, step_num, rules, entity_interaction.get(a.name, ""),
-                                trajectory_id=trajectory_id,
-                            ),
-                            timeout, max_concurrent,
-                        ) if agent_semaphore else _invoke_with_retry(
-                            a, board.workspace, step_num,
-                            build_prompt(
-                                a, step_num, rules, entity_interaction.get(a.name, ""),
-                                trajectory_id=trajectory_id,
-                            ),
-                            timeout,
-                        )
-                    )
-                    tg.create_task(_safe_invoke(coro))
+                    tg.create_task(_run_pop(a))
         except ExceptionGroup as eg:
             for exc in eg.exceptions:
                 logger.error(
@@ -453,7 +550,12 @@ async def _run_entity_step(
             duration_s=round(time.monotonic() - t1, 3),
         )
         for a in pop_agents:
-            p = parse_proposal(board.workspace, a.name, step_num)
+            output = pop_outputs.get(a.name)
+            p = None
+            if output:
+                p = parse_proposal_from_text(output, a.name)
+            if p is None:
+                p = parse_proposal(board.workspace, a.name, step_num)
             if p:
                 proposals.append(p)
                 board.save_proposal(p, step_num)
@@ -461,21 +563,24 @@ async def _run_entity_step(
     # Phase 3: Critics evaluate all proposals
     critic_agents = [a for e in critic_entities for a in e.agents]
     if critic_agents:
+        proposals_dicts = [p.model_dump() for p in proposals]
+        critic_kwargs = {**embed_kwargs, "proposals": proposals_dicts}
+
         logger.debug("entity_step.critics_start", step=step_num, n_agents=len(critic_agents))
         t2 = time.monotonic()
+        critic_outputs: dict[str, str | None] = {}
+
+        async def _run_critic(c):
+            prompt = build_prompt(c, step_num, rules, **critic_kwargs)
+            result = await _invoke_and_collect(
+                c, board.workspace, step_num, prompt, timeout, agent_semaphore, max_concurrent,
+            )
+            critic_outputs[c.name] = result
+
         try:
             async with asyncio.TaskGroup() as tg:
                 for c in critic_agents:
-                    coro = (
-                        _invoke_with_semaphore(
-                            agent_semaphore, c, board.workspace, step_num,
-                            build_prompt(c, step_num, rules), timeout, max_concurrent,
-                        ) if agent_semaphore else _invoke_with_retry(
-                            c, board.workspace, step_num,
-                            build_prompt(c, step_num, rules), timeout,
-                        )
-                    )
-                    tg.create_task(_safe_invoke(coro))
+                    tg.create_task(_run_critic(c))
         except ExceptionGroup as eg:
             for exc in eg.exceptions:
                 logger.error(
@@ -486,7 +591,12 @@ async def _run_entity_step(
             duration_s=round(time.monotonic() - t2, 3),
         )
         for c in critic_agents:
-            cr = parse_critique(board.workspace, c.name, step_num)
+            output = critic_outputs.get(c.name)
+            cr = None
+            if output:
+                cr = parse_critique_from_text(output, c.name)
+            if cr is None:
+                cr = parse_critique(board.workspace, c.name, step_num)
             if cr:
                 critiques.append(cr)
                 board.save_critique(cr, step_num)
@@ -498,10 +608,19 @@ async def _run_entity_step(
         logger.debug("entity_step.resolve_start", step=step_num)
         t3 = time.monotonic()
         judge = eval_agents[0]
-        await _invoke_with_retry(
-            judge, board.workspace, step_num, build_prompt(judge, step_num, rules), timeout,
+        judge_kwargs = {
+            **embed_kwargs,
+            "proposals": [p.model_dump() for p in proposals],
+            "critiques": [c.model_dump() for c in critiques],
+        }
+        prompt = build_prompt(judge, step_num, rules, **judge_kwargs)
+        judge_output = await _invoke_with_retry_return(
+            judge, board.workspace, step_num, prompt, timeout,
         )
-        resolution = parse_resolution(board.workspace, step_num)
+        if judge_output:
+            resolution = parse_resolution_from_text(judge_output)
+        if resolution is None:
+            resolution = parse_resolution(board.workspace, step_num)
         logger.debug(
             "entity_step.resolve_done", step=step_num,
             duration_s=round(time.monotonic() - t3, 3),

--- a/src/minimal_agora/providers/subprocess_provider.py
+++ b/src/minimal_agora/providers/subprocess_provider.py
@@ -15,7 +15,7 @@ class ClaudeSubprocessProvider:
 
     def __init__(
         self,
-        max_turns: int = 5,
+        max_turns: int = 1,
         output_format: str = "text",
     ) -> None:
         self.max_turns = max_turns

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -33,8 +33,8 @@ pytestmark = pytest.mark.integration
 
 
 class FileWritingMockProvider:
-    """Mock provider that writes proposal/critique/resolution JSON files to disk,
-    mimicking how the real subprocess provider operates."""
+    """Mock provider that returns JSON in stdout for inline parsing,
+    and also writes files to disk as a fallback path."""
 
     def __init__(self) -> None:
         self.call_count: int = 0
@@ -47,8 +47,14 @@ class FileWritingMockProvider:
         name_match = re.search(r"You are \*\*(\w+)\*\*", prompt)
         agent_name = name_match.group(1) if name_match else "unknown"
 
-        step_match = re.search(r"step_(\d{3})", prompt)
+        step_match = (
+            re.search(r"Simulation Step (\d+)", prompt)
+            or re.search(r"Proposals for Step (\d+)", prompt)
+            or re.search(r"step_(\d{3})", prompt)
+        )
         step_num = int(step_match.group(1)) if step_match else 0
+
+        output = "mock"
 
         if "an actor agent" in prompt:
             proposal = Proposal(
@@ -58,9 +64,7 @@ class FileWritingMockProvider:
                 reasoning=f"Mock evolution at step {step_num}",
                 confidence=0.8,
             )
-            path = workspace / "proposals" / f"step_{step_num:03d}_{agent_name}.json"
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(proposal.model_dump_json(indent=2))
+            output = proposal.model_dump_json(indent=2)
 
         elif "a critic agent" in prompt:
             critique = Critique(
@@ -70,9 +74,7 @@ class FileWritingMockProvider:
                 plausibility=0.85,
                 issues=[],
             )
-            path = workspace / "critiques" / f"step_{step_num:03d}_{agent_name}.json"
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(critique.model_dump_json(indent=2))
+            output = critique.model_dump_json(indent=2)
 
         elif "the judge agent" in prompt:
             resolution = Resolution(
@@ -80,11 +82,9 @@ class FileWritingMockProvider:
                 narrative=f"Step {step_num}: Mock changes applied.",
                 reasoning="All proposals deemed plausible.",
             )
-            path = workspace / "resolutions" / f"step_{step_num:03d}_resolution.json"
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(resolution.model_dump_json(indent=2))
+            output = resolution.model_dump_json(indent=2)
 
-        return AgentInvocationResult(output="mock", tokens_used=100, model="mock-model")
+        return AgentInvocationResult(output=output, tokens_used=100, model="mock-model")
 
 
 @pytest.fixture()

--- a/tests/test_prompt_embedding.py
+++ b/tests/test_prompt_embedding.py
@@ -1,0 +1,295 @@
+"""Tests for embedded state in agent prompts and text-based output parsing."""
+from __future__ import annotations
+
+import json
+
+from minimal_agora.agents import (
+    build_actor_prompt,
+    build_critic_prompt,
+    build_judge_prompt,
+    build_prompt,
+    parse_critique_from_text,
+    parse_proposal_from_text,
+    parse_resolution_from_text,
+)
+from minimal_agora.models import AgentConfig, AgentRole, SimRule
+from minimal_agora.providers.subprocess_provider import ClaudeSubprocessProvider
+
+
+def _make_agent(
+    name: str = "test_actor",
+    role: AgentRole = AgentRole.ACTOR,
+    perspective: str = "Test perspective",
+) -> AgentConfig:
+    return AgentConfig(role=role, name=name, perspective=perspective)
+
+
+SAMPLE_STATE = {"time": {"step": 3}, "population": 1000, "resources": {"food": 50}}
+SAMPLE_NARRATIVE = "## Step 1\nThings happened.\n\n## Step 2\nMore things happened."
+SAMPLE_WILDCARD = {
+    "name": "meteor_strike",
+    "description": "A large meteor hits the planet",
+    "state_impact": {"resources": {"food": -20}},
+}
+SAMPLE_PROPOSALS = [
+    {
+        "agent": "actor_1",
+        "role": "actor",
+        "proposed_changes": {"population": 1100},
+        "reasoning": "Growth period",
+        "confidence": 0.8,
+    },
+]
+SAMPLE_CRITIQUES = [
+    {
+        "agent": "critic_1",
+        "target_proposals": ["actor_1"],
+        "assessment": "Plausible",
+        "plausibility": 0.9,
+        "issues": [],
+    },
+]
+
+
+class TestActorPromptEmbedsState:
+    def test_state_json_in_prompt(self) -> None:
+        agent = _make_agent()
+        prompt = build_actor_prompt(agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE)
+        assert json.dumps(SAMPLE_STATE, indent=2) in prompt
+
+    def test_narrative_in_prompt(self) -> None:
+        agent = _make_agent()
+        prompt = build_actor_prompt(agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE)
+        assert "Things happened." in prompt
+        assert "More things happened." in prompt
+
+    def test_wildcard_in_prompt(self) -> None:
+        agent = _make_agent()
+        prompt = build_actor_prompt(
+            agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE, wildcard=SAMPLE_WILDCARD,
+        )
+        assert "meteor_strike" in prompt
+        assert "A large meteor hits the planet" in prompt
+        assert "MUST be accounted for" in prompt
+
+    def test_no_file_read_instructions_when_embedded(self) -> None:
+        agent = _make_agent()
+        prompt = build_actor_prompt(agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE)
+        assert "Read the current world state from" not in prompt
+        assert "board/state.json" not in prompt
+
+    def test_asks_for_json_stdout_when_embedded(self) -> None:
+        agent = _make_agent()
+        prompt = build_actor_prompt(agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE)
+        assert "Respond with ONLY a JSON object" in prompt
+
+    def test_fallback_without_state(self) -> None:
+        agent = _make_agent()
+        prompt = build_actor_prompt(agent, step=3)
+        assert "Read the current world state from `board/state.json`" in prompt
+        assert "Write your proposal as a JSON file" in prompt
+
+    def test_rules_still_included(self) -> None:
+        agent = _make_agent()
+        rules = [SimRule(name="Conservation", description="Energy is conserved")]
+        prompt = build_actor_prompt(
+            agent, step=3, rules=rules, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE,
+        )
+        assert "Conservation" in prompt
+        assert "Energy is conserved" in prompt
+
+    def test_diversity_lens_included(self) -> None:
+        agent = _make_agent()
+        prompt = build_actor_prompt(
+            agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE, trajectory_id=2,
+        )
+        assert "trajectory 2" in prompt
+
+
+class TestCriticPromptEmbedsProposals:
+    def test_proposals_in_prompt(self) -> None:
+        agent = _make_agent(name="critic_1", role=AgentRole.CRITIC)
+        prompt = build_critic_prompt(
+            agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE,
+            proposals=SAMPLE_PROPOSALS,
+        )
+        assert "actor_1" in prompt
+        assert "Growth period" in prompt
+
+    def test_state_in_prompt(self) -> None:
+        agent = _make_agent(name="critic_1", role=AgentRole.CRITIC)
+        prompt = build_critic_prompt(
+            agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE,
+            proposals=SAMPLE_PROPOSALS,
+        )
+        assert json.dumps(SAMPLE_STATE, indent=2) in prompt
+
+    def test_no_file_instructions_when_embedded(self) -> None:
+        agent = _make_agent(name="critic_1", role=AgentRole.CRITIC)
+        prompt = build_critic_prompt(
+            agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE,
+            proposals=SAMPLE_PROPOSALS,
+        )
+        assert "Read the current world state from" not in prompt
+        assert "Read ALL proposals" not in prompt
+
+    def test_fallback_without_state(self) -> None:
+        agent = _make_agent(name="critic_1", role=AgentRole.CRITIC)
+        prompt = build_critic_prompt(agent, step=3)
+        assert "Read the current world state from `board/state.json`" in prompt
+
+
+class TestJudgePromptEmbedsAll:
+    def test_proposals_and_critiques_in_prompt(self) -> None:
+        agent = _make_agent(name="judge_1", role=AgentRole.JUDGE)
+        prompt = build_judge_prompt(
+            agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE,
+            proposals=SAMPLE_PROPOSALS, critiques=SAMPLE_CRITIQUES,
+        )
+        assert "actor_1" in prompt
+        assert "Growth period" in prompt
+        assert "Plausible" in prompt
+        assert "critic_1" in prompt
+
+    def test_state_in_prompt(self) -> None:
+        agent = _make_agent(name="judge_1", role=AgentRole.JUDGE)
+        prompt = build_judge_prompt(
+            agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE,
+            proposals=SAMPLE_PROPOSALS, critiques=SAMPLE_CRITIQUES,
+        )
+        assert json.dumps(SAMPLE_STATE, indent=2) in prompt
+
+    def test_wildcard_in_prompt(self) -> None:
+        agent = _make_agent(name="judge_1", role=AgentRole.JUDGE)
+        prompt = build_judge_prompt(
+            agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE,
+            proposals=SAMPLE_PROPOSALS, critiques=SAMPLE_CRITIQUES, wildcard=SAMPLE_WILDCARD,
+        )
+        assert "meteor_strike" in prompt
+
+    def test_no_file_instructions_when_embedded(self) -> None:
+        agent = _make_agent(name="judge_1", role=AgentRole.JUDGE)
+        prompt = build_judge_prompt(
+            agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE,
+            proposals=SAMPLE_PROPOSALS, critiques=SAMPLE_CRITIQUES,
+        )
+        assert "Read the current world state from" not in prompt
+        assert "Read ALL proposals" not in prompt
+        assert "Read ALL critiques" not in prompt
+
+    def test_fallback_without_state(self) -> None:
+        agent = _make_agent(name="judge_1", role=AgentRole.JUDGE)
+        prompt = build_judge_prompt(agent, step=3)
+        assert "Read the current world state from `board/state.json`" in prompt
+
+
+class TestBuildPromptPassesKwargs:
+    def test_actor_receives_state(self) -> None:
+        agent = _make_agent()
+        prompt = build_prompt(agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE)
+        assert json.dumps(SAMPLE_STATE, indent=2) in prompt
+
+    def test_critic_receives_proposals(self) -> None:
+        agent = _make_agent(name="critic_1", role=AgentRole.CRITIC)
+        prompt = build_prompt(
+            agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE,
+            proposals=SAMPLE_PROPOSALS,
+        )
+        assert "Growth period" in prompt
+
+    def test_judge_receives_all(self) -> None:
+        agent = _make_agent(name="judge_1", role=AgentRole.JUDGE)
+        prompt = build_prompt(
+            agent, step=3, state=SAMPLE_STATE, narrative=SAMPLE_NARRATIVE,
+            proposals=SAMPLE_PROPOSALS, critiques=SAMPLE_CRITIQUES,
+        )
+        assert "Growth period" in prompt
+        assert "Plausible" in prompt
+
+
+class TestParseProposalFromText:
+    def test_valid_json(self) -> None:
+        text = json.dumps({
+            "agent": "test_actor",
+            "role": "actor",
+            "proposed_changes": {"x": 1},
+            "reasoning": "test",
+            "confidence": 0.8,
+        })
+        result = parse_proposal_from_text(text, "test_actor")
+        assert result is not None
+        assert result.agent == "test_actor"
+        assert result.proposed_changes == {"x": 1}
+
+    def test_json_in_markdown_block(self) -> None:
+        text = (
+            "Here is my proposal:\n"
+            "```json\n"
+            '{"agent": "test_actor", "role": "actor", '
+            '"proposed_changes": {"y": 2}, "reasoning": "test", "confidence": 0.9}\n'
+            "```\n"
+            "That's all."
+        )
+        result = parse_proposal_from_text(text, "test_actor")
+        assert result is not None
+        assert result.proposed_changes == {"y": 2}
+
+    def test_invalid_text(self) -> None:
+        result = parse_proposal_from_text("not json at all", "test_actor")
+        assert result is None
+
+    def test_valid_json_wrong_schema(self) -> None:
+        result = parse_proposal_from_text('{"foo": "bar"}', "test_actor")
+        assert result is None
+
+
+class TestParseCritiqueFromText:
+    def test_valid_json(self) -> None:
+        text = json.dumps({
+            "agent": "critic_1",
+            "target_proposals": ["actor_1"],
+            "assessment": "Good",
+            "plausibility": 0.9,
+            "issues": [],
+        })
+        result = parse_critique_from_text(text, "critic_1")
+        assert result is not None
+        assert result.agent == "critic_1"
+
+    def test_invalid_text(self) -> None:
+        assert parse_critique_from_text("garbage", "critic_1") is None
+
+
+class TestParseResolutionFromText:
+    def test_valid_json(self) -> None:
+        text = json.dumps({
+            "state_delta": {"x": 1},
+            "narrative": "Things changed.",
+            "reasoning": "Because.",
+        })
+        result = parse_resolution_from_text(text)
+        assert result is not None
+        assert result.state_delta == {"x": 1}
+
+    def test_json_in_code_block(self) -> None:
+        text = (
+            "```\n"
+            '{"state_delta": {"a": 2}, "narrative": "Done.", "reasoning": "OK."}\n'
+            "```"
+        )
+        result = parse_resolution_from_text(text)
+        assert result is not None
+        assert result.state_delta == {"a": 2}
+
+    def test_invalid_text(self) -> None:
+        assert parse_resolution_from_text("no json here") is None
+
+
+class TestMaxTurnsDefault:
+    def test_default_is_1(self) -> None:
+        provider = ClaudeSubprocessProvider()
+        assert provider.max_turns == 1
+
+    def test_custom_max_turns(self) -> None:
+        provider = ClaudeSubprocessProvider(max_turns=10)
+        assert provider.max_turns == 10

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -97,7 +97,7 @@ class TestClaudeSubprocessProvider:
             "--output-format",
             "text",
             "--max-turns",
-            "5",
+            "1",
             "--allowedTools",
             "Read,Write,Bash",
             "--add-dir",


### PR DESCRIPTION
Closes #27

## Changes
- **agents.py**: Updated `build_actor_prompt`, `build_critic_prompt`, `build_judge_prompt` to accept `state`, `narrative`, `wildcard`, `proposals`, `critiques` parameters and embed them directly in the prompt. When provided, prompts ask for JSON on stdout instead of file read/write instructions. Added `parse_proposal_from_text`, `parse_critique_from_text`, `parse_resolution_from_text` with markdown code block extraction. Updated `build_prompt` dispatcher to pass through `**kwargs`.
- **loop.py**: Updated `_run_flat_step` and `_run_entity_step` to read state/narrative once, pass to prompt builders, capture agent output text, and parse JSON responses directly. Added `_invoke_and_collect` and `_invoke_with_retry_return` helpers. Falls back to file-based parsing when text parsing fails.
- **subprocess_provider.py**: Changed `max_turns` default from 5 to 1 (no tool use needed with embedded prompts).
- **tests/test_prompt_embedding.py**: 31 new tests covering embedded state in prompts, text-based parsing (valid JSON, markdown blocks, invalid input), and max_turns default.
- Updated integration test mock to return JSON in stdout instead of writing files.

## Performance Impact
Eliminates 3-5 tool-use round-trips per agent invocation (~30-60s each), reducing each agent call to a single inference pass.